### PR TITLE
ObjectCursor performance and selection of indexed values

### DIFF
--- a/src/com/simperium/client/Bucket.java
+++ b/src/com/simperium/client/Bucket.java
@@ -122,6 +122,7 @@ public class Bucket<T extends Syncable> {
      * Cursor for bucket data
      */
     public interface ObjectCursor<T extends Syncable> extends Cursor {
+
         /**
          * Return the current item's siperium key
          */
@@ -130,6 +131,7 @@ public class Bucket<T extends Syncable> {
          * Return the object for the current index in the cursor
          */
         public T getObject();
+
     }
 
     private class BucketCursor extends CursorWrapper implements ObjectCursor<T> {
@@ -164,6 +166,7 @@ public class Bucket<T extends Syncable> {
             cache.put(key, object);
             return object;
         }
+
     }
     /**
      * Tell the bucket to sync changes.

--- a/src/com/simperium/client/BucketSchema.java
+++ b/src/com/simperium/client/BucketSchema.java
@@ -35,6 +35,9 @@ public abstract class BucketSchema<T extends Syncable> {
             return value;
         }
 
+        public String toString(){
+            return String.format("%s : %s", name, value);
+        }
     }
 
     private List<Indexer<T>> indexers = Collections.synchronizedList(new ArrayList<Indexer<T>>());
@@ -43,7 +46,7 @@ public abstract class BucketSchema<T extends Syncable> {
     public abstract T build(String key, Map<String,Object>properties);
     public abstract void update(T object, Map<String,Object>properties);
 
-    protected List<Index> indexesFor(T object){
+    public List<Index> indexesFor(T object){
         // run all of the indexers
         List<Index> indexes = new ArrayList<Index>();
         Iterator<Indexer<T>> indexerIterator = indexers.iterator();

--- a/src/com/simperium/client/GhostStore.java
+++ b/src/com/simperium/client/GhostStore.java
@@ -119,10 +119,10 @@ public class GhostStore implements GhostStoreProvider {
 		values.put(PAYLOAD_FIELD, payload);
 		if (cursor.getCount() > 0) {
 			int count = database.update(GHOSTS_TABLE_NAME, values, where, args);
-			Logger.log(String.format("Updated ghost(%d): %s.%d %s", count, ghost.getSimperiumKey(), ghost.getVersion(), payload));
+			Logger.log(String.format("Updated ghost(%d): %s.%d", count, ghost.getSimperiumKey(), ghost.getVersion()));
 		} else {
 			long id = database.insertOrThrow(GHOSTS_TABLE_NAME, null, values);
-			Logger.log(String.format("Created ghost(id:%d): %s.%d %s", id, ghost.getSimperiumKey(), ghost.getVersion(), payload));
+			Logger.log(String.format("Created ghost(id:%d): %s.%d", id, ghost.getSimperiumKey(), ghost.getVersion()));
 		}
 		cursor.close();
 	}

--- a/src/com/simperium/client/Query.java
+++ b/src/com/simperium/client/Query.java
@@ -122,6 +122,7 @@ public class Query<T extends Syncable> {
     private Bucket<T> bucket;
     private List<Comparator> conditions = new ArrayList<Comparator>();
     private List<Sorter> sorters = new ArrayList<Sorter>();
+    private List<String> keys = new ArrayList<String>();
 
     public Query(Bucket<T> bucket){
         this.bucket = bucket;
@@ -147,6 +148,10 @@ public class Query<T extends Syncable> {
 
     public List<Sorter> getSorters(){
         return sorters;
+    }
+
+    public List<String> getKeys(){
+        return keys;
     }
 
     public Bucket.ObjectCursor<T> execute(){
@@ -181,6 +186,24 @@ public class Query<T extends Syncable> {
 
     public Query order(String key, SortType type){
         order(new Sorter(key, type));
+        return this;
+    }
+
+    public Query reorder(){
+        sorters.clear();
+        return this;
+    }
+
+    public Query include(String key){
+        // we want to include some indexed values
+        keys.add(key);
+        return this;
+    }
+
+    public Query include(String ... keys){
+        for (String key : keys) {
+            this.keys.add(key);
+        }
         return this;
     }
 }

--- a/src/com/simperium/client/WebSocketManager.java
+++ b/src/com/simperium/client/WebSocketManager.java
@@ -218,7 +218,8 @@ public class WebSocketManager implements WebSocketClient.Listener, Channel.OnMes
     }
     public void onMessage(String message){
         scheduleHeartbeat();
-        Logger.log(TAG, String.format("%s <= %s", Thread.currentThread().getName(), message));
+        int size = message.length();
+        Logger.log(TAG, String.format("%s <= %s", Thread.currentThread().getName(), message.substring(0, size > 60 ? 60 : size)));
         String[] parts = message.split(":", 2);;
         if (parts[0].equals(COMMAND_HEARTBEAT)) {
             heartbeatCount = Integer.parseInt(parts[1]);

--- a/tests/unit_tests/src/com/simperium/tests/PersistentStoreTest.java
+++ b/tests/unit_tests/src/com/simperium/tests/PersistentStoreTest.java
@@ -187,7 +187,7 @@ public class PersistentStoreTest extends ActivityInstrumentationTestCase2<MainAc
         note.save();
 
         Cursor cursor = mDatabase.query(PersistentStore.INDEXES_TABLE, null, null, null, null, null, "name", null);
-        assertEquals(6, cursor.getCount());
+        assertEquals(7, cursor.getCount());
         cursor.moveToFirst();
         assertEquals(bucketName, cursor.getString(0));
         assertEquals(note.getSimperiumKey(), cursor.getString(1));
@@ -312,6 +312,21 @@ public class PersistentStoreTest extends ActivityInstrumentationTestCase2<MainAc
         cursor.moveToFirst();
         note = cursor.getObject();
         assertEquals(2, note.get("position"));
+    }
+
+    /**
+     * Tests pulling indexed values from the cursor for performance.
+     */
+    public void testSelectIndexValues(){
+        Note note = mBucket.newObject("thing");
+        note.setContent("Lol");
+        note.save();
+
+        Query<Note> query = mBucket.query().include("preview");
+        Bucket.ObjectCursor<Note> cursor = query.execute();
+        cursor.moveToFirst();
+        assertEquals(5, cursor.getColumnCount());
+        assertEquals("Lol", cursor.getString(4));
     }
 
     public static void assertTableExists(SQLiteDatabase database, String tableName){

--- a/tests/unit_tests/src/com/simperium/tests/models/Note.java
+++ b/tests/unit_tests/src/com/simperium/tests/models/Note.java
@@ -2,10 +2,16 @@ package com.simperium.tests.models;
 
 import com.simperium.client.BucketObject;
 import com.simperium.client.BucketSchema;
+import com.simperium.client.BucketSchema.Indexer;
+import com.simperium.client.BucketSchema.Index;
 
 import com.simperium.tests.models.Note;
 
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+
+import java.lang.StringBuilder;
 
 public class Note extends BucketObject {
     
@@ -14,7 +20,17 @@ public class Note extends BucketObject {
 
         public Schema(){
             autoIndex();
+            addIndex(contentIndexer);
         }
+
+        private Indexer<Note> contentIndexer = new Indexer<Note>(){
+            @Override
+            public List<Index> index(Note note){
+                List<Index> indexes = new ArrayList<Index>(1);
+                indexes.add(new Index("preview", note.getPreview()));
+                return indexes;
+            }
+        };
 
         @Override
         public String getRemoteName(){
@@ -32,6 +48,9 @@ public class Note extends BucketObject {
         }
     }
 
+    private static final String SPACE=" ";
+    private StringBuilder preview;
+
     public Note(String key, Map<String,Object> properties){
         super(key, properties);
     }
@@ -42,6 +61,15 @@ public class Note extends BucketObject {
 
     public String getTitle(){
         return (String) get("title");
+    }
+
+    public String getContent(){
+        return (String) get("content");
+    }
+
+    public void setContent(String content){
+        preview = null;
+        put("content", content);
     }
 
     public void put(String key, Object value){
@@ -58,5 +86,40 @@ public class Note extends BucketObject {
 
     protected void setProperties(Map<String,Object> properties){
         this.properties = properties;
+    }
+
+    public CharSequence getPreview(){
+        if (preview != null) {
+            return preview;
+        }
+        String content = getContent();
+        if (content == null) {
+            return "";
+        }
+        // just the first three lines
+        preview = new StringBuilder();
+        int start = 0;
+        int position = -1;
+        int lines = 0;
+        do {
+            position = content.indexOf("\n", start);
+            // if there are no new lines in the whole thing, we'll just take the whole thing
+            if (position == -1 && start == 0) {
+                position = content.length();
+            }
+            if (position > start + 1) {
+                int length = preview.length();
+                if (length > 0) {
+                    preview.append(SPACE);
+                }
+                preview.append(content.subSequence(start, position));
+                if (length > 320) {
+                    break;
+                }
+                lines ++;
+            }
+            start = position + 1;
+        } while(lines < 3 && position > -1 && start > 0);
+        return preview;
     }
 }


### PR DESCRIPTION
Queries can now stipulate additional indexes to include in the selection of
columns returned in the cursor allowing for higher performance in list views
since values can be retrieved from the cursor instead of requiring instantiation
of the underlying object.

Fixes issue #3 
