### PR TITLE
Reindexing

### DIFF
--- a/src/com/simperium/client/Syncable.java
+++ b/src/com/simperium/client/Syncable.java
@@ -9,7 +9,7 @@ import java.util.Map;
  */
 public abstract class Syncable implements Diffable {
     private Ghost ghost;
-    protected Bucket<? extends Syncable> bucket;
+    protected Bucket bucket;
 
     public Integer getVersion(){
         return ghost.getVersion();
@@ -70,5 +70,11 @@ public abstract class Syncable implements Diffable {
             return String.format("%s.?", getSimperiumKey());
         }
         return getGhost().getVersionId();
+    }
+
+    public void notifySaved(){
+        if (bucket != null) {
+            bucket.notifyOnSaveListeners(this);
+        }
     }
 }

--- a/src/com/simperium/client/WebSocketManager.java
+++ b/src/com/simperium/client/WebSocketManager.java
@@ -231,7 +231,7 @@ public class WebSocketManager implements WebSocketClient.Listener, Channel.OnMes
             Channel channel = channels.get(channelId);
             channel.receiveMessage(parts[1]);
         } catch (NumberFormatException e) {
-            Logger.log(TAG, String.format("Unhandled message %s", parts));
+            Logger.log(TAG, String.format("Unhandled message %s", parts[0]));
         }
     }
     public void onMessage(byte[] data){

--- a/src/com/simperium/storage/MemoryStore.java
+++ b/src/com/simperium/storage/MemoryStore.java
@@ -29,6 +29,12 @@ public class MemoryStore implements StorageProvider {
     
     class Storage<T extends Syncable> implements StorageProvider.BucketStore<T> {
         private Map<String, T> objects = Collections.synchronizedMap(new HashMap<String, T>(32));
+
+        @Override
+        public void prepare(Bucket<T> bucket){
+            // noop
+        }
+
         /**
          * Add/Update the given object
          */

--- a/src/com/simperium/storage/PersistentStore.java
+++ b/src/com/simperium/storage/PersistentStore.java
@@ -14,6 +14,7 @@ import android.database.Cursor;
 import android.database.CursorWrapper;
 import android.content.ContentValues;
 import android.os.CancellationSignal;
+import android.os.Handler;
 
 import java.util.Map;
 import java.util.Map.Entry;
@@ -60,28 +61,33 @@ public class PersistentStore implements StorageProvider {
         DataStore(String bucketName, BucketSchema<T> schema){
             this.schema = schema;
             this.bucketName = bucketName;
-            reindex();
         }
 
-        public void reindex(){
+        public void reindex(final Bucket<T> bucket){
             final CancellationSignal signal = new CancellationSignal();
             if (reindexThread != null && reindexThread.isAlive()) {
                 return;
             }
+            final Handler notifier = new Handler();
             reindexThread = new Thread(new Runnable(){
                 @Override
                 public void run(){
-                    Bucket.ObjectCursor<T> cursor = all(null);
+                    Bucket.ObjectCursor<T> cursor = bucket.allObjects(signal);
                     while(cursor.moveToNext()){
                         try {
-                            T object = cursor.getObject();
+                            final T object = cursor.getObject();
                             String key = cursor.getSimperiumKey();
                             if (skipIndexing.contains(key)) {
                                 Log.d(TAG, String.format("Skipped reindexing %s", key));
                                 continue;
                             }
                             index(object, schema.indexesFor(object));
-                            object.notifySaved();
+                            notifier.post(new Runnable(){
+                                @Override
+                                public void run(){
+                                    object.notifySaved();
+                                }
+                            });
                         } catch (SQLException e) {
                             Thread.currentThread().interrupt();
                             Log.d(TAG, "Reindexing canceled due to exception", e);
@@ -98,6 +104,11 @@ public class PersistentStore implements StorageProvider {
                 }
             });
             reindexThread.start();
+        }
+
+        @Override
+        public void prepare(Bucket<T> bucket){
+            reindex(bucket);
         }
 
         /**

--- a/src/com/simperium/storage/PersistentStore.java
+++ b/src/com/simperium/storage/PersistentStore.java
@@ -9,6 +9,7 @@ import com.simperium.client.BucketObjectMissingException;
 import com.simperium.client.Query;
 
 import android.database.sqlite.SQLiteDatabase;
+import android.database.SQLException;
 import android.database.Cursor;
 import android.database.CursorWrapper;
 import android.content.ContentValues;
@@ -21,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Set;
+import java.util.Collections;
 
 import org.json.JSONObject;
 import org.json.JSONException;
@@ -33,6 +35,8 @@ public class PersistentStore implements StorageProvider {
     public static final String INDEXES_TABLE="indexes";
 
     private SQLiteDatabase database;
+    private Thread reindexThread;
+    private List<String> skipIndexing = Collections.synchronizedList(new ArrayList<String>());
 
     public PersistentStore(SQLiteDatabase database){
         this.database = database;
@@ -58,6 +62,43 @@ public class PersistentStore implements StorageProvider {
             this.bucketName = bucketName;
         }
 
+        public void reindex(){
+            final CancellationSignal signal = new CancellationSignal();
+            if (reindexThread != null && reindexThread.isAlive()) {
+                return;
+            }
+            reindexThread = new Thread(new Runnable(){
+                @Override
+                public void run(){
+                    Bucket.ObjectCursor<T> cursor = all(null);
+                    while(cursor.moveToNext()){
+                        try {
+                            T object = cursor.getObject();
+                            String key = cursor.getSimperiumKey();
+                            if (skipIndexing.contains(key)) {
+                                Log.d(TAG, String.format("Skipped reindexing %s", key));
+                                continue;
+                            }
+                            index(object, schema.indexesFor(object));
+                            object.notifySaved();
+                        } catch (SQLException e) {
+                            Thread.currentThread().interrupt();
+                            Log.d(TAG, "Reindexing canceled due to exception", e);
+                        }
+                        if (Thread.interrupted()) {
+                            signal.cancel();
+                            cursor.close();
+                            skipIndexing.clear();
+                            return;
+                        }
+                    }
+                    cursor.close();
+                    skipIndexing.clear();
+                }
+            });
+            reindexThread.start();
+        }
+
         /**
          * Add/Update the given object
          */
@@ -74,6 +115,7 @@ public class PersistentStore implements StorageProvider {
             } else {
                 database.update(OBJECTS_TABLE, values, "bucket=? AND key=?", new String[]{bucketName, key});
             }
+            skipIndexing.add(key);
             index(object, indexes);
         }
 
@@ -83,6 +125,7 @@ public class PersistentStore implements StorageProvider {
         @Override
         public void delete(T object){
             String key = object.getSimperiumKey();
+            skipIndexing.add(key);
             database.delete(OBJECTS_TABLE, "bucket=? AND key=?", new String[]{bucketName, key});
             deleteIndexes(object);
         }
@@ -134,7 +177,7 @@ public class PersistentStore implements StorageProvider {
             return buildCursor(schema, cursor);
         }
         
-        private void index(T object, List<Index> indexValues){
+        protected void index(T object, List<Index> indexValues){
             // delete all current idexes
             deleteIndexes(object);
             Log.d(TAG, String.format("Index %d values for %s", indexValues.size(), object.getSimperiumKey()));

--- a/src/com/simperium/storage/PersistentStore.java
+++ b/src/com/simperium/storage/PersistentStore.java
@@ -60,6 +60,7 @@ public class PersistentStore implements StorageProvider {
         DataStore(String bucketName, BucketSchema<T> schema){
             this.schema = schema;
             this.bucketName = bucketName;
+            reindex();
         }
 
         public void reindex(){

--- a/src/com/simperium/storage/StorageProvider.java
+++ b/src/com/simperium/storage/StorageProvider.java
@@ -18,31 +18,44 @@ public interface StorageProvider {
      * Store and query bucket object data
      */
     public interface BucketStore<T extends Syncable> {
+
+        /**
+         * For initializing and performaing any necessary setup for storing
+         * bucket data.
+         */
+        abstract public void prepare(Bucket<T> bucket);
+
         /**
          * Add/Update the given object
          */
         abstract public void save(T object, List<Index> indexes);
+
         /**
          * Remove the given object from the storage
          */
         abstract public void delete(T object);
+
         /**
          * Delete all objects from storage
          */
         abstract public void reset();
+
         /**
          * Get an object with the given key
          */
         abstract public T get(String key) throws BucketObjectMissingException;
+
         /**
          * All objects, returns a cursor for the given bucket
          */
         abstract public Bucket.ObjectCursor<T> all(CancellationSignal cancelSignal);
+
         /**
          * 
          */
         abstract public Bucket.ObjectCursor<T> search(Query<T> query, CancellationSignal cancelSignal);
     }
+
     /**
      * 
      */


### PR DESCRIPTION
Now that indexes can be defined by developers at any time, this provides a way for StorageProviders to update their underlying data to account for the new indexing routines.
