### PR TITLE
Revisions

### DIFF
--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -13,8 +13,7 @@ repositories {
 }
 
 dependencies {
-    compile files('libs/android-websockets.jar')
-    compile files('libs/android-async-http-1.4.3.jar')
+    compile fileTree(dir: 'libs', include:'*.jar')
 }
 
 android {

--- a/Simperium/src/main/java/com/simperium/Simperium.java
+++ b/Simperium/src/main/java/com/simperium/Simperium.java
@@ -9,6 +9,7 @@ import com.simperium.storage.PersistentStore;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObject;
 import com.simperium.client.BucketSchema;
+import com.simperium.client.ChannelProvider;
 import com.simperium.client.Channel;
 import com.simperium.client.GhostStore;
 import com.simperium.client.Syncable;
@@ -140,7 +141,7 @@ public class Simperium implements User.AuthenticationListener {
     public <T extends Syncable> Bucket<T> bucket(String bucketName, BucketSchema<T> schema){
         BucketStore<T> storage = storageProvider.createStore(bucketName, schema);
         Bucket<T> bucket = new Bucket<T>(bucketName, schema, user, storage, ghostStore);
-        Bucket.ChannelProvider<T> channel = socketManager.createChannel(bucket, channelSerializer);
+        ChannelProvider<T> channel = socketManager.createChannel(bucket, channelSerializer);
         bucket.setChannel(channel);
         storage.prepare(bucket);
         return bucket;

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -411,10 +411,9 @@ public class Bucket<T extends Syncable> {
      * Add object from new ghost data, no corresponding change version so this
      * came from an index request
      */
-    protected void addObjectWithGhost(Ghost ghost){
+    public void addObjectWithGhost(Ghost ghost){
         ghostStore.saveGhost(this, ghost);
         T object = buildObject(ghost);
-        Logger.log(TAG, "Built object with ghost, add it");
         addObject(object);
     }
     /**
@@ -485,10 +484,14 @@ public class Bucket<T extends Syncable> {
         removeOnNetworkChangeListener(listener);
     }
     
+    public Channel.RevisionsRequest getRevisions(T object, RevisionsRequestCallbacks<T> callbacks){
+        return getRevisions(object.getSimperiumKey(), object.getVersion(), callbacks);
+    }
+
     /**
      * Request revision history for object with the given key
      */
-    public Channel.RevisionsRequest getRevisions(String key, final RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
+    public Channel.RevisionsRequest getRevisions(String key, RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
         int version = 0;
         try {
             version = ghostStore.getGhostVersion(this, key);            
@@ -496,6 +499,10 @@ public class Bucket<T extends Syncable> {
             callbacks.onError(e);
             throw e;
         }
+        return getRevisions(key, version, callbacks);
+    }
+
+    public Channel.RevisionsRequest getRevisions(String key, int version, final RevisionsRequestCallbacks<T> callbacks){
         return channel.getRevisions(key, version, new ChannelProvider.RevisionsRequestCallbacks(){
 
             @Override

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -20,6 +20,8 @@ import com.simperium.Simperium;
 import com.simperium.util.JSONDiff;
 import com.simperium.util.Logger;
 
+import com.simperium.client.ChannelProvider.RevisionsRequest;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EventObject;
@@ -29,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.Scanner;
+
+import java.text.ParseException;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -49,6 +53,8 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
     static final String FIELD_BUCKET_NAME = "name";
     static final String FIELD_COMMAND     = "cmd";
 
+    public static final String NEW_LINE   = "\n";
+
     // commands sent over the socket
     public static final String COMMAND_INIT      = "init"; // init:{INIT_PROPERTIES}
     public static final String COMMAND_AUTH      = "auth"; // received after an init: auth:expired or auth:email@example.com
@@ -56,6 +62,8 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
     public static final String COMMAND_CHANGE    = "c";
     public static final String COMMAND_VERSION   = "cv";
     public static final String COMMAND_ENTITY    = "e";
+
+    public static final String ENTITY_DATA_KEY = "data";
 
     static final String RESPONSE_UNKNOWN  = "?";
 
@@ -106,6 +114,61 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
             this.queued = queuedChanges;
         }
     }
+
+    private class RevisionsCollector implements ChannelProvider.RevisionsRequest {
+
+        final private String key, prefix;
+        final private int sinceVersion;
+        final private ChannelProvider.RevisionsRequestCallbacks callbacks;
+        private boolean completed = true;
+        private boolean sent = false;
+        private List<Integer> versions = Collections.synchronizedList(new ArrayList<Integer>());
+
+        RevisionsCollector(String key, int sinceVersion, ChannelProvider.RevisionsRequestCallbacks callbacks){
+            this.key = key;
+            this.prefix = String.format("%s.", key);
+            this.sinceVersion = sinceVersion;
+            this.callbacks = callbacks;
+        }
+
+        private void send(){
+            if (!sent) {
+                sent = true;
+                // for each version send an e: request
+                for (int i=1; i<sinceVersion; i++) {
+                    sendObjectRequest(key, i);
+                }
+            }
+        }
+
+        public void addObjectData(ObjectVersion objectVersion){
+            int version = objectVersion.getVersion();
+            if (objectVersion.getKey().equals(this.key) && version < sinceVersion && versions.indexOf(version) == -1) {
+                versions.add(version);
+                try {
+                    JSONObject data = objectVersion.parsePayload();
+                    callbacks.onRevision(key, version, convertJSON(data));                    
+                } catch (JSONException e) {
+                    callbacks.onError(e);
+                    revisionCollectors.remove(this);
+                    completed = true;
+                    return;
+                }
+                if (versions.size() == sinceVersion-1 ) {
+                    revisionCollectors.remove(this);
+                    completed = true;
+                    callbacks.onComplete();
+                }
+            }
+        }
+
+        @Override
+        public boolean isComplete(){
+            return completed;
+        }
+    }
+
+    private List<RevisionsCollector> revisionCollectors = Collections.synchronizedList(new ArrayList<RevisionsCollector>());
 
     public Channel(String appId, String sessionId, final Bucket<T> bucket, Serializer serializer, OnMessageListener listener){
         this.serializer = serializer;
@@ -219,8 +282,13 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
     }
 
     @Override
-    public ChannelProvider.RevisionsRequest getRevisions(String key, int sinceVersion, ChannelProvider.RevisionsRequestCallbacks callbacks){
-        return null;
+    public ChannelProvider.RevisionsRequest getRevisions(String key, int sinceVersion, final ChannelProvider.RevisionsRequestCallbacks callbacks){
+        // for the key and version iterate down requesting the each version for the object
+        RevisionsCollector collector = new RevisionsCollector(key, sinceVersion, callbacks);
+        revisionCollectors.add(collector);
+        collector.send();
+        // collect the responses back
+        return collector;
     }
 
     private static final String INDEX_CURRENT_VERSION_KEY = "current";
@@ -296,13 +364,23 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
         Logger.log(TAG, String.format("Received %d change(s)", changes.length()));
     }
 
-    private static final String ENTITY_DATA_KEY = "data";
     private void handleVersionResponse(String versionData){
         // versionData will be: key.version\n{"data":ENTITY}
         // we need to parse out the key and version, parse the json payload and
         // retrieve the data
-        if (indexProcessor == null || !indexProcessor.addObjectData(versionData)) {
-          Logger.log(TAG, String.format("Unkown Object for index: %s", versionData));
+        try {
+            ObjectVersion objectVersion = ObjectVersion.parseVersionData(versionData);
+            if (indexProcessor == null || !indexProcessor.addObjectData(objectVersion)) {
+              Logger.log(TAG, String.format("Unkown Object for index: %s", objectVersion.getKey()));
+            }
+            // if we have any revision requests pending, we want to collect the objects
+            Iterator<RevisionsCollector> collectors = revisionCollectors.iterator();
+            while(collectors.hasNext()){
+                RevisionsCollector collector = collectors.next();
+                collector.addObjectData(objectVersion);
+            }
+        } catch (ParseException e) {
+            Logger.log(TAG, "Invalid object version", e);
         }
 
     }
@@ -386,6 +464,10 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
         // send a message
         MessageEvent event = new MessageEvent(this, message);
         emit(event);
+    }
+
+    private void sendObjectRequest(String key, int version){
+        sendMessage(String.format("%s:%s.%d", COMMAND_ENTITY, key, version));
     }
 
     private void emit(MessageEvent event){
@@ -498,17 +580,80 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
 
     }
 
-    private class ObjectVersion {
+    private static class ObjectVersion {
         private String key;
         private Integer version;
+        private String payload;
+        private JSONObject parsedPayload;
+        private boolean payloadPresent = false;
+        private boolean unknown = false;
 
         public ObjectVersion(String key, Integer version){
             this.key = key;
             this.version = version;
         }
 
+        public int getVersion(){
+            return version;
+        }
+
+        public String getKey(){
+            return key;
+        }
+
+        public boolean hasPayload(){
+            return payloadPresent;
+        }
+
+        public boolean isUnknown(){
+            return unknown;
+        }
+
         public String toString(){
             return String.format("%s.%d", key, version);
+        }
+
+        public JSONObject parsePayload() throws JSONException {
+            if (parsedPayload != null) {
+                return parsedPayload;
+            }
+            JSONObject payloadJSON = new JSONObject(payload);
+            parsedPayload = payloadJSON.getJSONObject(ENTITY_DATA_KEY);
+            return parsedPayload;
+        }
+
+        /**
+         * Parses a full e: response with JSON payload
+         */
+        public static ObjectVersion parseVersionData(String versionData) throws ParseException {
+            int delimiter = versionData.indexOf(NEW_LINE);
+            if (delimiter == -1) {
+                throw new ParseException("Missing payload", 0);
+            }
+
+            String prefix = versionData.substring(0, delimiter);
+            int lastDot = prefix.lastIndexOf(".");
+            if (lastDot == -1) throw new ParseException(String.format("Missing version string: %s", prefix), prefix.length());
+
+            String key = prefix.substring(0, lastDot);
+            int version = 0;
+            try {
+                version = Integer.parseInt(prefix.substring(lastDot + 1));
+            } catch (NumberFormatException e) {
+                throw new ParseException("Invalid version number", lastDot + 1);
+            }
+
+            ObjectVersion object = new ObjectVersion(key, version);
+            String payload = versionData.substring(delimiter + 1);
+            if (payload.equals(RESPONSE_UNKNOWN)) {
+                object.unknown = true;
+                return object;
+            }
+
+            object.payload = payload;
+            object.payloadPresent = true;
+
+            return object;
         }
     }
     private interface IndexProcessorListener {
@@ -542,52 +687,28 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
             this.cv = cv;
             this.listener = listener;
         }
-        public Boolean addObjectData(String versionData){
+        public Boolean addObjectData(ObjectVersion objectVersion){
 
-            String[] objectParts = versionData.split("\n");
-            String prefix = objectParts[0];
-            int lastDot = prefix.lastIndexOf(".");
-            if (lastDot == -1) {
-                Logger.log(TAG, String.format("Missing version string: %s", prefix));
-                return false;
-            }
-            String key = prefix.substring(0, lastDot);
-            String version = prefix.substring(lastDot + 1);
-            String payload = objectParts[1];
-
-            if (payload.equals(RESPONSE_UNKNOWN)) {
-                Logger.log(TAG, String.format("Object unkown to simperium: %s.%s", key, version));
+            if(!index.remove(objectVersion.toString())){
+                Logger.log(TAG, String.format("Index didn't have %s", objectVersion));
                 return false;
             }
 
-            ObjectVersion objectVersion = new ObjectVersion(key, Integer.parseInt(version));
-            synchronized(index){
-                if(!index.remove(objectVersion.toString())){
-                    Logger.log(TAG, String.format("Index didn't have %s", objectVersion));
-                    return false;
-                }
-            }
-            Logger.log(TAG, String.format("We were waiting for %s.%s", key, version));
-
-            JSONObject data = null;
             try {
-                JSONObject payloadJSON = new JSONObject(payload);
-                data = payloadJSON.getJSONObject(ENTITY_DATA_KEY);
+                JSONObject data = objectVersion.parsePayload();
+                // build the ghost and update
+                Map<String,Object> properties = Channel.convertJSON(data);
+                Ghost ghost = new Ghost(objectVersion.getKey(), objectVersion.getVersion(), properties);
+                bucket.addObjectWithGhost(ghost);
+                indexedCount ++;
+                if (complete && index.size() == 0) {
+                    notifyDone();
+                } else if(indexedCount % 10 == 0) {
+                    notifyProgress();
+                }
             } catch (JSONException e) {
                 Logger.log(TAG, "Failed to parse object JSON", e);
                 return false;
-            }
-
-            Integer remoteVersion = Integer.parseInt(version);
-            // build the ghost and update
-            Map<String,Object> properties = Channel.convertJSON(data);
-            Ghost ghost = new Ghost(key, remoteVersion, properties);
-            bucket.addObjectWithGhost(ghost);
-            indexedCount ++;
-            if (complete && index.size() == 0) {
-                notifyDone();
-            } else if(indexedCount % 10 == 0) {
-                notifyProgress();
             }
 
             return true;
@@ -629,7 +750,7 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
                         if (!bucket.hasKeyVersion(key, versionNumber)) {
                             // we need to get the remote object
                             index.add(objectVersion.toString());
-                            sendMessage(String.format("%s:%s.%d", COMMAND_ENTITY, key, versionNumber));
+                            sendObjectRequest(key, versionNumber);
                         } else {
                             Logger.log(TAG, String.format("Object is up to date: %s", version));
                         }
@@ -711,7 +832,7 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
         public void onComplete();
     }
     
-    private boolean haveCompleteIndex(){
+    public boolean haveCompleteIndex(){
         return haveIndex;
     }
 
@@ -995,6 +1116,7 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
             if (change.requiresDiff()) {
                 Map<String,Object> diff = change.getDiff(); // jsondiff.diff(change.getOrigin(), change.getTarget());
                 if (diff.isEmpty()) {
+                    Logger.log(TAG, String.format("Diff is empty, not sending %s", change.getChangeId()));
                     return false;
                 }
                 map.put(JSONDiff.DIFF_VALUE_KEY, diff.get(JSONDiff.DIFF_VALUE_KEY));
@@ -1043,7 +1165,7 @@ public class Channel<T extends Syncable> implements ChannelProvider<T> {
                     list.add(val);
                 }
             } catch (JSONException e) {
-                Logger.log(TAG, String.format("Faile to convert JSON: %s", e.getMessage()), e);
+                Logger.log(TAG, String.format("Failed to convert JSON: %s", e.getMessage()), e);
             }
 
         }

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -38,7 +38,7 @@ import org.json.JSONTokener;
 import android.os.Handler;
 import android.os.HandlerThread;
 
-public class Channel<T extends Syncable> implements Bucket.ChannelProvider<T> {
+public class Channel<T extends Syncable> implements ChannelProvider<T> {
 
     public static final String TAG="Simperium.Channel";
     // key names for init command json object
@@ -167,10 +167,12 @@ public class Channel<T extends Syncable> implements Bucket.ChannelProvider<T> {
         });
     }
 
+    @Override
     public boolean isIdle(){
         return changeProcessor == null || changeProcessor.isIdle();
     }
 
+    @Override
     public void reset(){
         changeProcessor.reset();
         if (started) {
@@ -202,16 +204,23 @@ public class Channel<T extends Syncable> implements Bucket.ChannelProvider<T> {
     /**
      * Diffs and object's local modifications and queues up the changes
      */
+    @Override
     public Change<T> queueLocalChange(T object){
         Change<T> change = new Change<T>(Change.OPERATION_MODIFY, object);
         changeProcessor.addChange(change);
         return change;
     }
 
+    @Override
     public Change<T> queueLocalDeletion(T object){
         Change<T> change = new Change<T>(Change.OPERATION_REMOVE, object);
         changeProcessor.addChange(change);
         return change;
+    }
+
+    @Override
+    public ChannelProvider.RevisionsRequest getRevisions(String key, int sinceVersion, ChannelProvider.RevisionsRequestCallbacks callbacks){
+        return null;
     }
 
     private static final String INDEX_CURRENT_VERSION_KEY = "current";
@@ -312,6 +321,7 @@ public class Channel<T extends Syncable> implements Bucket.ChannelProvider<T> {
     /**
      * Send Bucket's init message to start syncing changes.
      */
+    @Override
     public void start(){
         if (started) {
             // we've already started

--- a/Simperium/src/main/java/com/simperium/client/ChannelProvider.java
+++ b/Simperium/src/main/java/com/simperium/client/ChannelProvider.java
@@ -1,0 +1,22 @@
+package com.simperium.client;
+
+import java.util.Map;
+
+public interface ChannelProvider<T extends Syncable> {
+    public Change<T> queueLocalChange(T object);
+    public Change<T> queueLocalDeletion(T object);
+    public RevisionsRequest getRevisions(String key, int sinceVersion, RevisionsRequestCallbacks callbacks);
+    public boolean isIdle();
+    public void start();
+    public void reset();
+
+    public interface RevisionsRequest {
+        public boolean isComplete();
+    }
+    
+    public interface RevisionsRequestCallbacks {
+        public void onError(Throwable exception);
+        public void onRevision(String key, int version, Map<String,Object> properties);
+        public void onComplete();
+    }
+}

--- a/Simperium/src/main/java/com/simperium/client/GhostStore.java
+++ b/Simperium/src/main/java/com/simperium/client/GhostStore.java
@@ -145,6 +145,22 @@ public class GhostStore implements GhostStoreProvider {
         }
 		return ghost;
 	}
+
+    @Override
+    public int getGhostVersion(Bucket bucket, String key) throws GhostMissingException {
+        String[] columns = { VERSION_FIELD };
+        String where = "bucketName=? AND simperiumKey=?";
+        String[] args = { bucket.getName(), key };
+
+        Cursor cursor = database.query(GHOSTS_TABLE_NAME, columns, where, args, null, null, "version DESC", "1");
+        int version = -1;
+        if(cursor.moveToFirst()){
+            version = cursor.getInt(0);
+        }
+        cursor.close();
+        if (version == -1) throw(new GhostMissingException(String.format("Ghost %s does not exist for bucket %s", bucket.getName(), key)));
+        return version;
+    }
 	
     @Override
 	public boolean hasGhost(Bucket bucket, String key){

--- a/Simperium/src/main/java/com/simperium/client/GhostStoreProvider.java
+++ b/Simperium/src/main/java/com/simperium/client/GhostStoreProvider.java
@@ -25,6 +25,11 @@ public interface GhostStoreProvider {
      * Builds a ghost from the provided bucket and key
      */
     public Ghost getGhost(Bucket bucket, String key) throws GhostMissingException;
+
+    /**
+     * Get the currently stored version number for the key in the bucket
+     */
+    public int getGhostVersion(Bucket bucket, String key) throws GhostMissingException;
     /**
      * Saves the provided ghost to the bucket
      */

--- a/Simperium/src/main/java/com/simperium/client/Syncable.java
+++ b/Simperium/src/main/java/com/simperium/client/Syncable.java
@@ -43,25 +43,35 @@ public abstract class Syncable implements Diffable {
     public void setBucket(Bucket bucket){
         this.bucket = bucket;
     }
-    
+
     /**
      * Returns the object as it should appear on the server
      */
     public Map<String, Object>getUnmodifiedValue(){
         return getGhost().getDiffableValue();
     }
+
     /**
      * Send modifications over the socket to simperium
      */
     public Change save(){
         return getBucket().sync(this);
     }
+
     /**
      * Sends a delete operation over the socket
      */
     public Change delete(){
         return getBucket().remove(this);
     }
+
+    /**
+     * Get this object's revisions
+     */
+    public ChannelProvider.RevisionsRequest getRevisions(Bucket.RevisionsRequestCallbacks<? extends Syncable> callbacks){
+        return getBucket().getRevisions(this, callbacks);
+    }
+
     /**
      * Key.VersionId
      */
@@ -72,9 +82,4 @@ public abstract class Syncable implements Diffable {
         return getGhost().getVersionId();
     }
 
-    public void notifySaved(){
-        if (bucket != null) {
-            bucket.notifyOnSaveListeners(this);
-        }
-    }
 }

--- a/Simperium/src/main/java/com/simperium/client/WebSocketManager.java
+++ b/Simperium/src/main/java/com/simperium/client/WebSocketManager.java
@@ -66,7 +66,7 @@ public class WebSocketManager implements WebSocketClient.Listener, Channel.OnMes
      * Creates a channel for the bucket. Starts the websocket connection if not connected
      *
      */
-    public <T extends Syncable> Bucket.ChannelProvider<T> createChannel(Bucket<T> bucket, Channel.Serializer serializer){
+    public <T extends Syncable> ChannelProvider<T> createChannel(Bucket<T> bucket, Channel.Serializer serializer){
         // create a channel
         Channel<T> channel = new Channel<T>(appId, sessionId, bucket, serializer, this);
         int channelId = channels.size();

--- a/Simperium/src/main/java/com/simperium/util/Logger.java
+++ b/Simperium/src/main/java/com/simperium/util/Logger.java
@@ -7,11 +7,11 @@ public class Logger {
     public static final String TAG = "Simperium";
 
     public static final void log(String msg){
-        Log.d(TAG, msg);
+        Log.v(TAG, msg);
     }
 
     public static final void log(String tag, String msg){
-        Log.d(tag, msg);
+        Log.v(tag, msg);
     }
 
     public static final void log(String msg, Throwable error){

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/BucketTest.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/BucketTest.java
@@ -71,7 +71,7 @@ public class BucketTest extends SimperiumTest {
         assertFalse(note.isNew());
     }
     
-    public void testObjectHistory(){
+    public void testObjectHistory() throws Exception {
         String key = "fake-history";
         // put a fake ghost in the ghost store
         Map<String,Object> properties = new HashMap<String,Object>(2);
@@ -84,22 +84,29 @@ public class BucketTest extends SimperiumTest {
         
         assertEquals(2, history.receivedRevisions);
         assertEquals("Title 1", history.notes[0].getTitle());
+        assertTrue(history.complete);
     }
     
     class RevisionsReceiver implements Bucket.RevisionsRequestCallbacks<Note> {
 
         public int receivedRevisions = 0;
         public Note[] notes = new Note[2];
+        public boolean complete = false;
 
         @Override
         public void onComplete(){
-            
+            complete = true;
         }
 
         @Override
         public void onRevision(String key, int version, Note note){
             notes[version-1] = note;
             receivedRevisions ++;
+        }
+
+        @Override
+        public void onError(Throwable error){
+            
         }
     }
 }

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/BucketTest.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/BucketTest.java
@@ -5,10 +5,12 @@ import static com.simperium.testapp.TestHelpers.*;
 import com.simperium.client.Change;
 import com.simperium.client.RemoteChange;
 import com.simperium.client.Bucket;
+import com.simperium.client.ChannelProvider;
 import com.simperium.client.BucketSchema;
 import com.simperium.client.ObjectCache;
 import com.simperium.client.GhostStoreProvider;
 import com.simperium.client.User;
+import com.simperium.client.Ghost;
 import com.simperium.storage.MemoryStore;
 
 import com.simperium.util.Uuid;
@@ -21,6 +23,9 @@ import com.simperium.testapp.mock.MockGhostStore;
 
 import org.json.JSONArray;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class BucketTest extends SimperiumTest {
 
     public static final String TAG="SimperiumTest";
@@ -28,7 +33,7 @@ public class BucketTest extends SimperiumTest {
     private BucketSchema<Note> mSchema;
     private User mUser;
     private GhostStoreProvider mGhostStore;
-    private Bucket.ChannelProvider<Note> mChannel;
+    private ChannelProvider<Note> mChannel;
 
     private static String BUCKET_NAME="local-notes";
 
@@ -65,5 +70,36 @@ public class BucketTest extends SimperiumTest {
         // acknowledge(note.save());
         assertFalse(note.isNew());
     }
+    
+    public void testObjectHistory(){
+        String key = "fake-history";
+        // put a fake ghost in the ghost store
+        Map<String,Object> properties = new HashMap<String,Object>(2);
+        properties.put("title", "Hello World");
+        properties.put("content", "Lorem ipsum");
+        RevisionsReceiver history = new RevisionsReceiver();
+        
+        mGhostStore.saveGhost(mBucket, new Ghost(key, 3, properties));
+        ChannelProvider.RevisionsRequest request = mBucket.getRevisions(key, history);
+        
+        assertEquals(2, history.receivedRevisions);
+        assertEquals("Title 1", history.notes[0].getTitle());
+    }
+    
+    class RevisionsReceiver implements Bucket.RevisionsRequestCallbacks<Note> {
 
+        public int receivedRevisions = 0;
+        public Note[] notes = new Note[2];
+
+        @Override
+        public void onComplete(){
+            
+        }
+
+        @Override
+        public void onRevision(String key, int version, Note note){
+            notes[version-1] = note;
+            receivedRevisions ++;
+        }
+    }
 }

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/ChannelTest.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/ChannelTest.java
@@ -1,0 +1,180 @@
+package com.simperium.testapp;
+
+import com.simperium.testapp.mock.MockBucket;
+import com.simperium.testapp.models.Note;
+
+import com.simperium.client.Bucket;
+import com.simperium.client.ChannelProvider;
+import com.simperium.client.Channel;
+import com.simperium.client.Channel.SerializedQueue;
+import com.simperium.client.Change;
+import com.simperium.client.Syncable;
+import com.simperium.client.User;
+
+import java.lang.InterruptedException;
+import java.lang.RuntimeException;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+
+public class ChannelTest extends SimperiumTest implements MockBucket.ChannelFactory {
+
+    Channel mChannel;
+    MockSocket mMockSocket;
+    Bucket<Note> mBucket;
+    Channel.MessageEvent mLastMessage;
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        mMockSocket = new MockSocket();
+        mBucket = MockBucket.buildBucket(new Note.Schema(), this);
+        mBucket.getUser().setAuthenticationStatus(User.AuthenticationStatus.AUTHENTICATED);
+        mChannel.onConnect();
+        mBucket.start();
+    }
+
+    public void testInit(){
+        String initMessage = "init:{\"clientid\":\"fake-session\",\"api\":1,\"app_id\":\"fake-app\",\"cmd\":\"i::::500\",\"token\":\"fake-token\",\"name\":\"notes\"}";
+
+        assertEquals(initMessage, mLastMessage.toString());
+        assertTrue(mChannel.haveCompleteIndex());
+    }
+
+    public void testNewChange() throws Exception {
+        mLastMessage = null;
+        Note note = mBucket.newObject("fake-note");
+        note.setTitle("A note");
+        Change change = note.save();
+        assertEquals(Change.OPERATION_MODIFY, change.getOperation());
+        assertEquals(0, (int) change.getVersion());
+        // we need to let the channel's change processor thread operate
+        while(!change.isSent()) Thread.sleep(100);
+
+        assertTrue(change.isSent());
+        MessageDetails details = MessageDetails.parse(mLastMessage);
+        assertEquals(change.getChangeId(), details.json.getString(Change.CHANGE_ID_KEY));
+    }
+
+    public void testRevisionRequest() throws Exception {
+        String key = "fake-object";
+        int version = 10, revisions = version-1;
+        mMockSocket.clearHistory();
+        RevisionReceiver history = new RevisionReceiver();
+        ChannelProvider.RevisionsRequest request = mChannel.getRevisions(key, version, history);
+        // send fake entities to the channel
+        sendRevisions(key, version);
+        
+        // make 9 e: requests
+        assertEquals(revisions, mMockSocket.history.size());
+
+        // we should wait until the revision request is complete
+        while(!request.isComplete()) Thread.sleep(100);
+
+        assertTrue(history.complete);
+        assertEquals(revisions, history.revisionCount);
+    }
+
+    public <T extends Syncable> ChannelProvider<T> buildChannel(Bucket<T> bucket){
+        // public Channel(String appId, String sessionId, final Bucket<T> bucket, Serializer serializer, OnMessageListener listener){
+        mChannel = new Channel<T>("fake-app", "fake-session", bucket, new MockSerializer(), mMockSocket );
+        return mChannel;
+    }
+
+    protected void sendRevisions(String key, int count){
+        sendRevisions(key, count, new RevisionBuilder(){
+            @Override
+            public String buildObjectVersion(String key, int version){
+                return String.format("{\"%s\":{\"title\":\"%s.%d\"}}", Channel.ENTITY_DATA_KEY, key, version);
+            }
+        });
+    }
+
+    protected void sendRevisions(String key, int count, RevisionBuilder builder){
+        for (int i=1; i<count; i++) {
+            mChannel.receiveMessage(String.format("%s:%s.%d\n%s",
+                Channel.COMMAND_ENTITY, key, i, builder.buildObjectVersion(key, i)));
+        }
+    }
+
+    interface RevisionBuilder {
+        String buildObjectVersion(String key, int i);
+    }
+
+    private class MockSocket implements Channel.OnMessageListener {
+
+        public List<Channel.MessageEvent> history = Collections.synchronizedList(new ArrayList<Channel.MessageEvent>());
+
+        @Override
+        public void onMessage(Channel.MessageEvent event){
+            // parse out the message
+            history.add(0, event);
+            String[] parts = event.toString().split(":", 2);
+            if (parts[0].equals("init")) {
+                // give it an empty bucket index
+                mChannel.receiveMessage("i:{\"index\":[]}");
+            }
+            mLastMessage = event;
+        }
+
+        public void clearHistory(){
+            history.clear();
+        }
+
+    }
+
+    private class MockSerializer implements Channel.Serializer {
+        public <T extends Syncable> void save(Bucket<T> bucket, SerializedQueue<T> data){}
+
+        public <T extends Syncable> SerializedQueue<T> restore(Bucket<T> bucket){
+            return new SerializedQueue<T>();
+        }
+
+        public <T extends Syncable> void reset(Bucket<T> bucket){}
+
+    }
+
+    private static class MessageDetails {
+
+        public JSONObject json;
+        public String command;
+
+        MessageDetails(String command, JSONObject details){
+            this.command = command;
+            this.json = details;
+        }
+
+        public static MessageDetails parse(Channel.MessageEvent event) throws JSONException {
+            String[] parts = event.toString().split(":", 2);
+            return new MessageDetails(parts[0], new JSONObject(parts[1]));
+        }
+
+    }
+
+    private class RevisionReceiver implements ChannelProvider.RevisionsRequestCallbacks {
+
+        public boolean complete = false;
+        public int revisionCount = 0;
+
+        @Override
+        public void onComplete(){
+            complete = true;
+        }
+
+        @Override
+        public void onRevision(String key, int version, Map<String,Object> properties){
+            revisionCount ++;
+        }
+
+        @Override
+        public void onError(Throwable exception){
+            throw new RuntimeException(exception);
+        }
+    }
+
+}

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/PersistentStoreTest.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/PersistentStoreTest.java
@@ -11,7 +11,7 @@ import android.database.Cursor;
 import com.simperium.storage.PersistentStore;
 
 import com.simperium.client.Bucket;
-import com.simperium.client.Bucket.ChannelProvider;
+import com.simperium.client.ChannelProvider;
 import com.simperium.client.BucketSchema;
 import com.simperium.client.Query;
 import com.simperium.client.ObjectCache;

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/SimperiumTest.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/SimperiumTest.java
@@ -5,7 +5,6 @@ import static com.simperium.testapp.TestHelpers.*;
 import junit.framework.TestCase;
 
 import com.simperium.client.Change;
-import com.simperium.client.User;
 import com.simperium.util.Logger;
 
 public class SimperiumTest extends TestCase {
@@ -37,6 +36,5 @@ public class SimperiumTest extends TestCase {
     static protected void tick(){
         waitFor(1);
     }
-    
 
 }

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockBucket.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockBucket.java
@@ -1,7 +1,7 @@
 package com.simperium.testapp.mock;
 
 import com.simperium.client.Bucket;
-import com.simperium.client.Bucket.ChannelProvider;
+import com.simperium.client.ChannelProvider;
 import com.simperium.client.BucketSchema;
 import com.simperium.client.GhostStoreProvider;
 import com.simperium.client.ObjectCache;

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockChannel.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockChannel.java
@@ -103,4 +103,5 @@ public class MockChannel<T extends Syncable> implements ChannelProvider<T> {
         ack.isAcknowledgedBy(change);
         mBucket.acknowledgeChange(ack, change);
     }
+
 }

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockChannel.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockChannel.java
@@ -4,7 +4,7 @@
 package com.simperium.testapp.mock;
 
 import com.simperium.client.Bucket;
-import com.simperium.client.Bucket.ChannelProvider;
+import com.simperium.client.ChannelProvider;
 import com.simperium.client.Syncable;
 import com.simperium.client.Change;
 import com.simperium.client.RemoteChange;
@@ -13,6 +13,8 @@ import com.simperium.util.Uuid;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
 
 public class MockChannel<T extends Syncable> implements ChannelProvider<T> {
 
@@ -56,6 +58,24 @@ public class MockChannel<T extends Syncable> implements ChannelProvider<T> {
     @Override
     public boolean isIdle(){
         return true;
+    }
+
+    @Override
+    public ChannelProvider.RevisionsRequest getRevisions(String key, int sinceVersion, ChannelProvider.RevisionsRequestCallbacks callbacks){
+        for(int i=1;i<sinceVersion;i++){
+            Map<String,Object> map = new HashMap<String,Object>();
+            map.put("title", String.format("Title %d", i));
+            map.put("content", String.format("Content %d", i));
+            callbacks.onRevision(key, i, map);
+        }
+        callbacks.onComplete();
+        // mock history request that is always complete
+        return new ChannelProvider.RevisionsRequest(){
+            @Override
+            public boolean isComplete(){
+                return true;
+            }
+        };
     }
 
     /**

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockGhostStore.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/mock/MockGhostStore.java
@@ -65,6 +65,13 @@ public class MockGhostStore implements GhostStoreProvider {
         return ghost;
     }
 
+    @Override
+    public int getGhostVersion(Bucket bucket, String key) throws GhostMissingException{
+        Map<String,Ghost> ghosts = ghostsForBucket(bucket);
+        Ghost ghost = getGhost(bucket, key);
+        return ghost.getVersion();
+    }
+
     /**
      * Saves the provided ghost to the bucket
      */
@@ -91,7 +98,7 @@ public class MockGhostStore implements GhostStoreProvider {
         data.put(bucket.getName(), new HashMap<String,Ghost>());
     }
     
-    protected Map<String,Ghost> ghostsForBucket(Bucket bucket){
+    public Map<String,Ghost> ghostsForBucket(Bucket bucket){
         String name = bucket.getName();
         Map<String,Ghost> ghosts = data.get(name);
         if (ghosts == null) {

--- a/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/models/Note.java
+++ b/SimperiumUnitTests/src/instrumentTest/java/com/simperium/testapp/models/Note.java
@@ -6,6 +6,7 @@ import com.simperium.client.BucketSchema.Indexer;
 import com.simperium.client.BucketSchema.Index;
 
 import java.util.Map;
+import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -50,6 +51,10 @@ public class Note extends BucketObject {
 
     private static final String SPACE=" ";
     private StringBuilder preview;
+
+    public Note(String key){
+        this(key, new HashMap<String,Object>());
+    }
 
     public Note(String key, Map<String,Object> properties){
         super(key, properties);


### PR DESCRIPTION
Provides a way to retrieve a specific object's revisions from the socket. Currently passes the revisions directly to the callback implementation so nothing is stored on the client.
