### PR TITLE
Kitkat init failure

### DIFF
--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -24,12 +24,12 @@ dependencies {
 
 android {
 
-    compileSdkVersion 18
+    compileSdkVersion 19
     buildToolsVersion "18.1.1"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 18
+        targetSdkVersion 19
     }
 
     sourceSets {

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -117,9 +117,12 @@ public final class Version {
 tasks.preBuild.dependsOn versionConfig
 
 task writePom << {
+    // if there's some trailing version cruft replace with SNAPSHOT
+    def artifactVersion = (project.version =~ /[^\d]$/) ? "$project.version-SNAPSHOT" : project.version
     ["simperium-android", "simperium-android-support"].each() { artifact ->
         pom {
             project {
+                version artifactVersion
                 artifactId artifact
                 packaging "aar"
             }

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -395,7 +395,7 @@ public class Channel implements Bucket.Channel {
         init.put(FIELD_APP_ID, appId);
         init.put(FIELD_AUTH_TOKEN, bucket.getUser().getAccessToken());
         init.put(FIELD_BUCKET_NAME, bucket.getRemoteName());
-        init.put(FIELD_COMMAND, initialCommand);
+        init.put(FIELD_COMMAND, initialCommand.toString());
         init.put(FIELD_LIBRARY_VERSION, LIBRARY_VERSION);
         init.put(FIELD_LIBRARY, LIBRARY_NAME);
         String initParams = new JSONObject(init).toString();


### PR DESCRIPTION
The `init` message sent by the bucket as `null` for the `cmd` attribute which causes the remote side to close the socket.

For fixing #46
