### PR TITLE
Download full object when error encountered

### DIFF
--- a/Simperium/AndroidManifest.xml
+++ b/Simperium/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+      android:allowBackup="false"
       android:icon="@drawable/ic_launcher">
         <activity
           android:name="com.simperium.android.LoginActivity"

--- a/Simperium/src/instrumentTest/java/com/simperium/ChangeTest.java
+++ b/Simperium/src/instrumentTest/java/com/simperium/ChangeTest.java
@@ -1,0 +1,75 @@
+package com.simperium;
+
+import com.simperium.client.Change;
+import com.simperium.client.Bucket;
+import com.simperium.client.Syncable;
+
+import com.simperium.models.Note;
+
+import com.simperium.test.MockBucket;
+
+import junit.framework.TestCase;
+
+import org.json.JSONObject;
+
+public class ChangeTest extends TestCase {
+
+    private Bucket<Note> mBucket;
+    private Note mNote;
+
+    protected void setUp()
+    throws Exception {
+
+        mBucket = MockBucket.buildBucket(new Note.Schema());
+
+    }
+
+    public void testModifyPayload()
+    throws Exception {
+
+        Note note = mBucket.newObject();
+        note.setTitle("Hello world");
+
+        Change change = new Change(Change.OPERATION_MODIFY, note);
+
+        assertTrue(change.isModifyOperation());
+        assertValidChangeObject(note, change);
+
+        JSONObject diff = change.toJSONObject().getJSONObject("v");
+
+        String expected = "{\"tags\":{\"v\":[],\"o\":\"+\"},\"deleted\":{\"v\":false,\"o\":\"+\"},\"title\":{\"v\":\"Hello world\",\"o\":\"+\"}}";
+        assertEquals(expected, diff.toString());
+
+    }
+
+    public void testDeletePayload()
+    throws Exception {
+
+        Note note = mBucket.newObject();
+        note.setTitle("Hello world");
+        note.save();
+
+        Change change = new Change(Change.OPERATION_REMOVE, note);
+
+        assertTrue(change.isRemoveOperation());
+        assertValidChangeObject(note, change);
+
+    }
+
+    public static void assertValidChangeObject(Syncable object, Change change)
+    throws Exception {
+
+        JSONObject changeJSON = change.toJSONObject();
+
+        assertNotNull("Change missing ccid", changeJSON.optString("ccid"));
+        assertNotNull("Change missing operation key `o`", changeJSON.optString("o"));
+        assertEquals("Change id is incorrect", object.getSimperiumKey(), changeJSON.getString("id"));
+
+        if (change.isRemoveOperation()) {
+            assertFalse("Remove operation has a diff value", changeJSON.has("v"));
+        } else {
+            assertNotNull("Modify operation has no patch", changeJSON.optJSONObject("v"));
+        }
+    }
+
+}

--- a/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
@@ -534,6 +534,50 @@ public class ChannelTest extends BaseSimperiumTest {
     }
 
     /**
+     * Handle receiving an entity when index has already been downloaded
+     */
+    public void testReceiveObjectDataWithExistingIndex()
+    throws Exception {
+
+        startWithEmptyIndex();
+
+        JSONObject data = new JSONObject();
+        data.put("title", "my hovercraft is full of eels");
+        ChannelUtil.sendObject(mChannel, "object", 5, data);
+
+        mExecutor.run();
+
+        Note note = mBucket.get("object");
+
+        assertEquals(5, (int) note.getVersion());
+        assertEquals("my hovercraft is full of eels", note.getTitle());
+
+    }
+
+    /**
+     * Receive full object data for an object we already have
+     */
+    public void testReceiveObjectDataWithExistingObject()
+    throws Exception {
+
+        Map<String,String> index = new HashMap<String,String>(1);
+        index.put("object.4", "{\"data\":{\"tags\":[],\"deleted\":false,\"title\":\"my hovercraft was full of eels\"}}");
+        startWithIndex("version-x", index);
+
+        JSONObject data = new JSONObject();
+        data.put("title", "my hovercraft is full of eels");
+        ChannelUtil.sendObject(mChannel, "object", 5, data);
+
+        mExecutor.run();
+
+        Note note = mBucket.get("object");
+
+        assertEquals(5, (int) note.getVersion());
+        assertEquals("my hovercraft is full of eels", note.getTitle());
+
+    }
+
+    /**
      * Get's the channel into a started state
      */
     protected void start(){

--- a/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
@@ -514,7 +514,7 @@ public class ChannelTest extends BaseSimperiumTest {
     }
 
     /**
-     * If we receive a remote request for an object version we don't have,
+     * If we receive a remote change for an object version we don't have,
      * request the entire object.
      */
     public void testRequestObjectForUnseenVersion()
@@ -528,10 +528,32 @@ public class ChannelTest extends BaseSimperiumTest {
 
         mExecutor.run();
 
-        // the channel should have requested unkown-key.5
+        // the channel should have requested unkown-key.6
         assertEquals("e:unknown-key.6", mListener.lastMessage.toString());
 
     }
+
+    /**
+     * If we receive a remote change we can't apply, request the entire object
+     */
+        public void testRequestObjectForInvalidChange()
+        throws Exception {
+
+            Map objects = new HashMap();
+            objects.put("mock.4", "{\"data\":{\"title\":\"Hello world.\"}}");
+            startWithIndex("mockcv", objects);
+
+            // diff cannot be applied
+            JSONObject diff = new JSONObject("{\"title\":{\"o\":\"d\",\"v\":\"=14\\t-1\\t+wa\\t=10\"}}");
+            ChannelUtil.sendModifyOperation(mChannel, "mock", 4, diff);
+
+            mExecutor.run();
+
+            // the channel should have requested unkown-key.5
+            assertEquals("e:mock.5", mListener.lastMessage.toString());
+
+        }
+
 
     /**
      * Handle receiving an entity when index has already been downloaded

--- a/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
@@ -1,12 +1,18 @@
 package com.simperium;
 
 import com.simperium.Version;
+
 import com.simperium.client.Bucket;
 import com.simperium.client.Channel;
 import com.simperium.client.ChannelProvider;
 import com.simperium.client.RemoteChange;
 import com.simperium.client.User;
+
 import com.simperium.models.Note;
+
+import com.simperium.util.RemoteChangesUtil;
+import com.simperium.util.ChannelUtil;
+
 import com.simperium.test.MockBucket;
 import com.simperium.test.MockChannelListener;
 import com.simperium.test.MockChannelSerializer;
@@ -489,12 +495,7 @@ public class ChannelTest extends BaseSimperiumTest {
 
         assertTrue("Bucket should have an instance of mock1", mBucket.containsKey("mock1"));
         // receive a remotely initiated delete operation for mock1
-        JSONObject change = new JSONObject();
-        change.put("ccids", new JSONArray("[\"random-ccid\"]"));
-        change.put("clientid", "otherclient");
-        change.put("cv", "new-cv");
-        change.put("o", "-");
-        change.put("id", "mock1");
+        JSONObject change = RemoteChangesUtil.deleteOperation("mock1");
         mChannel.receiveMessage(String.format("c:[%s]", change));
 
         // pause bucket execution to simulate concurrent threads

--- a/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/instrumentTest/java/com/simperium/ChannelTest.java
@@ -511,6 +511,25 @@ public class ChannelTest extends BaseSimperiumTest {
 
         assertNull(mListener.lastMessage);
 
+    }
+
+    /**
+     * If we receive a remote request for an object version we don't have,
+     * request the entire object.
+     */
+    public void testRequestObjectForUnseenVersion()
+    throws Exception {
+
+        startWithEmptyIndex();
+
+        // receive a change for an object we don't have
+        JSONObject diff = new JSONObject("{\"title\":{\"o\":\"r\",\"v\":\"My hovercraft is full of eels\"}}");
+        ChannelUtil.sendModifyOperation(mChannel, "unknown-key", 5, diff);
+
+        mExecutor.run();
+
+        // the channel should have requested unkown-key.5
+        assertEquals("e:unknown-key.6", mListener.lastMessage.toString());
 
     }
 

--- a/Simperium/src/main/java/com/simperium/android/AndroidClient.java
+++ b/Simperium/src/main/java/com/simperium/android/AndroidClient.java
@@ -71,7 +71,7 @@ public class AndroidClient implements ClientFactory {
         }
 
         if (sessionToken == null) {
-            sessionToken = Uuid.uuid().substring(0,6);
+            sessionToken = Uuid.uuid(6);
             preferences.edit().putString(SESSION_ID_PREFERENCE, sessionToken).apply();
         }
 

--- a/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
+++ b/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -148,7 +149,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
         // if we have channels, then connect, otherwise wait for a channel
         cancelReconnect();
         if (!isConnected() && !isConnecting() && !channels.isEmpty()) {
-            Logger.log(TAG, String.format("Connecting to %s", socketURI));
+            Logger.log(TAG, String.format(Locale.US, "Connecting to %s", socketURI));
             setConnectionStatus(ConnectionStatus.CONNECTING);
             reconnect = true;
             socketClient.connect();
@@ -226,7 +227,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
 
     synchronized private void sendHearbeat() {
         heartbeatCount ++;
-        String command = String.format("%s:%d", COMMAND_HEARTBEAT, heartbeatCount);
+        String command = String.format(Locale.US, "%s:%d", COMMAND_HEARTBEAT, heartbeatCount);
 
         if(!isConnected()) return;
 
@@ -252,7 +253,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
                 connect();
             }
         }, retryIn);
-        Logger.log(String.format("Retrying in %d", retryIn));
+        Logger.log(String.format(Locale.US, "Retrying in %d", retryIn));
     }
 
     // duplicating javascript reconnect interval calculation
@@ -277,7 +278,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
         Channel channel = (Channel)event.getSource();
         Integer channelId = channelIndex.get(channel);
         // Prefix the message with the correct channel id
-        String message = String.format("%d:%s", channelId, event.getMessage());
+        String message = String.format(Locale.US, "%d:%s", channelId, event.getMessage());
 
         if(isConnected()){
             socketClient.send(message);
@@ -293,7 +294,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
         for (Channel channel : channels.values()) {
             if (channel.isStarted()) return;
         }
-        Logger.log(TAG, String.format("%s disconnect from socket", Thread.currentThread().getName()));
+        Logger.log(TAG, String.format(Locale.US, "%s disconnect from socket", Thread.currentThread().getName()));
         disconnect();
     }
 
@@ -347,7 +348,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
             Channel channel = channels.get(channelId);
             channel.receiveMessage(parts[1]);
         } catch (NumberFormatException e) {
-            Logger.log(TAG, String.format("Unhandled message %s", parts[0]));
+            Logger.log(TAG, String.format(Locale.US, "Unhandled message %s", parts[0]));
         }
     }
 
@@ -355,7 +356,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
     }
 
     public void onDisconnect(int code, String reason) {
-        Logger.log(TAG, String.format("Disconnect %d %s", code, reason));
+        Logger.log(TAG, String.format(Locale.US, "Disconnect %d %s", code, reason));
         setConnectionStatus(ConnectionStatus.DISCONNECTED);
         notifyChannelsDisconnected();
         cancelHeartbeat();
@@ -363,7 +364,7 @@ public class WebSocketManager implements ChannelProvider, WebSocketClient.Listen
     }
 
     public void onError(Exception error) {
-        Logger.log(TAG, String.format("Error: %s", error), error);
+        Logger.log(TAG, String.format(Locale.US, "Error: %s", error), error);
         setConnectionStatus(ConnectionStatus.DISCONNECTED);
         if (java.io.IOException.class.isAssignableFrom(error.getClass()) && reconnect) {
             scheduleReconnect();

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -497,6 +497,7 @@ public class Bucket<T extends Syncable> {
         storage.save(object, schema.indexesFor(object));
         // notify listeners that an object has been added
     }
+
     /**
      * Updates an existing object
      */
@@ -504,6 +505,7 @@ public class Bucket<T extends Syncable> {
         object.setBucket(this);
         storage.save(object, schema.indexesFor(object));
     }
+
     /**
      *
      */

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -191,7 +191,6 @@ public class Bucket<T extends Syncable> {
      * Tell the bucket to sync changes.
      */
     public void sync(final T object){
-        // we want to do all the hard work in a different thread, let's just build one right here and see what kind of improvements we get
         executor.execute(new Runnable(){
             @Override
             public void run(){
@@ -417,15 +416,6 @@ public class Bucket<T extends Syncable> {
         ghostStore.saveGhost(this, ghost);
         cache.put(name, object);
         return object;
-    }
-
-    /**
-     * Save the ghost data and update the change version, tell the storage provider
-     * that a new object has been added
-     */
-    protected void addObjectWithGhost(String changeVersion, Ghost ghost){
-        setChangeVersion(changeVersion);
-        addObjectWithGhost(ghost);
     }
 
     /**

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -674,7 +674,7 @@ public class Bucket<T extends Syncable> {
                 // update the object's ghost
                 object.setGhost(ghost);
             } catch (BucketObjectMissingException e) {
-                throw(new RemoteChangeInvalidException(e));
+                throw(new RemoteChangeInvalidException(remoteChange, e));
             }
         } else {
             ghostStore.deleteGhost(this, remoteChange.getKey());
@@ -693,7 +693,7 @@ public class Bucket<T extends Syncable> {
                 removeObjectWithKey(change.getKey());
                 ghostStore.deleteGhost(this, change.getKey());
             } catch (BucketObjectMissingException e) {
-                throw(new RemoteChangeInvalidException(e));
+                throw(new RemoteChangeInvalidException(change, e));
             }
         } else {
             try {
@@ -720,7 +720,7 @@ public class Bucket<T extends Syncable> {
                 }
             } catch(SimperiumException e) {
                 Logger.log(TAG, String.format("Unable to apply remote change %s", change), e);
-                throw(new RemoteChangeInvalidException(e));
+                throw(new RemoteChangeInvalidException(change, e));
             }
         }
         setChangeVersion(change.getChangeVersion());

--- a/Simperium/src/main/java/com/simperium/client/Change.java
+++ b/Simperium/src/main/java/com/simperium/client/Change.java
@@ -184,6 +184,32 @@ public class Change {
         return version;
     }
 
+    protected JSONObject toJSONObject()
+    throws ChangeEmptyException, ChangeInvalidException {
+        try {
+            JSONObject json = new JSONObject();
+            json.put(ID_KEY, getKey());
+            json.put(CHANGE_ID_KEY, getChangeId());
+            json.put(JSONDiff.DIFF_OPERATION_KEY, getOperation());
+
+            Integer vresion = getVersion();
+            if (version != null && version > 0) {
+                json.put(SOURCE_VERSION_KEY, version);
+            }
+
+            JSONObject diff = getDiff();
+
+            if (requiresDiff() && diff.length() == 0) {
+                throw new ChangeEmptyException(this);
+            }
+
+            json.put(JSONDiff.DIFF_VALUE_KEY, diff);
+            return json;
+        } catch (JSONException e) {
+            throw new ChangeInvalidException(this, "Could not build change JSON", e);
+        }
+    }
+
     protected Map<String,Object> toJSONSerializable(){
         Map<String,Object> props = new HashMap<String,Object>(3);
         // key, version, origin, target, ccid

--- a/Simperium/src/main/java/com/simperium/client/Change.java
+++ b/Simperium/src/main/java/com/simperium/client/Change.java
@@ -184,7 +184,7 @@ public class Change {
         return version;
     }
 
-    protected JSONObject toJSONObject()
+    public JSONObject toJSONObject()
     throws ChangeEmptyException, ChangeInvalidException {
         try {
             JSONObject json = new JSONObject();
@@ -198,12 +198,16 @@ public class Change {
             }
 
             JSONObject diff = getDiff();
+            boolean requiresDiff = requiresDiff();
 
-            if (requiresDiff() && diff.length() == 0) {
+            if (requiresDiff && diff.length() == 0) {
                 throw new ChangeEmptyException(this);
             }
 
-            json.put(JSONDiff.DIFF_VALUE_KEY, diff);
+            if (requiresDiff) {
+                json.put(JSONDiff.DIFF_VALUE_KEY, diff.getJSONObject(JSONDiff.DIFF_VALUE_KEY));
+            }
+
             return json;
         } catch (JSONException e) {
             throw new ChangeInvalidException(this, "Could not build change JSON", e);
@@ -253,7 +257,7 @@ public class Change {
     /**
      * The change message requires a diff value in the JSON payload
      */
-    public Boolean requiresDiff(){
+    public boolean requiresDiff(){
         return operation.equals(OPERATION_MODIFY);
     }
 

--- a/Simperium/src/main/java/com/simperium/client/ChangeEmptyException.java
+++ b/Simperium/src/main/java/com/simperium/client/ChangeEmptyException.java
@@ -1,0 +1,25 @@
+package com.simperium.client;
+
+/**
+ * When a Change object does not produce any actual change this exception is
+ * thrown.
+ */
+public class ChangeEmptyException extends ChangeException {
+
+    public ChangeEmptyException(Change change) {
+        super(change);
+    }
+
+    public ChangeEmptyException(Change change, String message) {
+        super(change, message);
+    }
+
+    public ChangeEmptyException(Change change, String message, Throwable cause) {
+        super(change, message, cause);
+    }
+
+    public ChangeEmptyException(Change change, Throwable cause) {
+        super(change, cause);
+    }
+
+}

--- a/Simperium/src/main/java/com/simperium/client/ChangeException.java
+++ b/Simperium/src/main/java/com/simperium/client/ChangeException.java
@@ -1,0 +1,37 @@
+package com.simperium.client;
+
+import com.simperium.SimperiumException;
+
+/**
+ * Base exception for exceptions related to Change instances.
+ */
+public class ChangeException extends SimperiumException {
+
+    public final Change change;
+
+    public ChangeException(Change change) {
+        super();
+        this.change = change;
+    }
+
+    public ChangeException(Change change, String message) {
+        super(message);
+        this.change = change;
+    }
+
+    public ChangeException(Change change, String message, Throwable cause) {
+        super(message, cause);
+        this.change = change;
+    }
+
+    public ChangeException(Change change, Throwable cause) {
+        super(cause);
+        this.change = change;
+    }
+
+    public Change getChange() {
+        return this.change;
+    }
+
+
+}

--- a/Simperium/src/main/java/com/simperium/client/ChangeInvalidException.java
+++ b/Simperium/src/main/java/com/simperium/client/ChangeInvalidException.java
@@ -1,0 +1,25 @@
+package com.simperium.client;
+
+/**
+ * When a Change object is unable to create the JSON representation for any
+ * reason this exception is thrown.
+ */
+public class ChangeInvalidException extends ChangeException {
+
+    public ChangeInvalidException(Change change) {
+        super(change);
+    }
+
+    public ChangeInvalidException(Change change, String message) {
+        super(change, message);
+    }
+
+    public ChangeInvalidException(Change change, String message, Throwable cause) {
+        super(change, message, cause);
+    }
+
+    public ChangeInvalidException(Change change, Throwable cause) {
+        super(change, cause);
+    }
+
+}

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -676,7 +676,7 @@ public class Channel implements Bucket.Channel {
         private String mark = "";
         private Integer limit = INDEX_PAGE_SIZE;
 
-        public IndexQuery(){};
+        public IndexQuery(){}
 
         public IndexQuery(String mark){
             this(mark, INDEX_PAGE_SIZE);
@@ -958,7 +958,6 @@ public class Channel implements Bucket.Channel {
         private Timer retryTimer;
         
         private final Object lock = new Object();
-        public Object runLock = new Object();
 
         public ChangeProcessor() {
             restore();
@@ -1091,7 +1090,7 @@ public class Channel implements Bucket.Channel {
 
                     if(processLocalChange()){
                         executor.execute(this);
-                    };
+                    }
 
                     return;
                 }
@@ -1122,7 +1121,6 @@ public class Channel implements Bucket.Channel {
                 RemoteChange remoteChange = RemoteChange.buildFromMap(remoteJSON);
                 log(LOG_DEBUG, String.format("Processing remote change with cv: %s", remoteChange.getChangeVersion()));
 
-                boolean acknowledged = false;
                 Change change = pendingChanges.get(remoteChange.getKey());
 
                 // one of our changes is being acknowledged
@@ -1184,7 +1182,6 @@ public class Channel implements Bucket.Channel {
 
             } catch (JSONException e) {
                 Logger.log(TAG, "Failed to build remote change", e);
-                return;
             }
 
         }

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -8,10 +8,6 @@
  * 
  * To get messages into a Channel, Channel.receiveMessage receives a Simperium
  * websocket API message stripped of the channel ID prefix.
- * 
- * TODO: instead of notifying the bucket about each individual item, there should be
- * a single event for when there's a "re-index" or after performing all changes in a
- * change operation.
  *
  */
 package com.simperium.client;

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -301,11 +301,6 @@ public class Channel implements Bucket.Channel {
         Logger.log(TAG, String.format("Received error from service %s", remoteChange));
     }
 
-    protected Ghost onRemote(RemoteChange remoteChange)
-    throws RemoteChangeInvalidException {
-        return bucket.applyRemoteChange(remoteChange);
-    }
-
     @Override
     public void reset(){
         changeProcessor.reset();
@@ -1314,7 +1309,7 @@ public class Channel implements Bucket.Channel {
                         log(LOG_DEBUG, String.format("Received error response for change but not waiting for any ccids <%s>", remoteChange.getChangeVersion()));
                     } else {
                         try {
-                            onRemote(remoteChange);
+                            bucket.applyRemoteChange(remoteChange);
                             Logger.log(TAG, String.format("Succesfully applied remote change <%s>", remoteChange.getChangeVersion()));
                         } catch (RemoteChangeInvalidException e) {
                             Logger.log(TAG, "Remote change could not be applied", e);

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -719,7 +719,7 @@ public class Channel implements Bucket.Channel {
         }
 
         public String toString(){
-            return String.format("%s.%d", key, version);
+            return String.format(Locale.US, "%s.%d", key, version);
         }
 
         public static ObjectVersion parseString(String versionString)

--- a/Simperium/src/main/java/com/simperium/client/Ghost.java
+++ b/Simperium/src/main/java/com/simperium/client/Ghost.java
@@ -2,6 +2,8 @@ package com.simperium.client;
 
 import org.json.JSONObject;
 
+import java.util.Locale;
+
 public class Ghost implements Diffable {
 
     private String key;
@@ -29,9 +31,9 @@ public class Ghost implements Diffable {
         return properties;
     }
     public String getVersionId(){
-        return String.format("%s.%d", key, version);
+        return String.format(Locale.US, "%s.%d", key, version);
     }
     public String toString(){
-        return String.format("Ghost %s", getVersionId());
+        return String.format(Locale.US, "Ghost %s", getVersionId());
     }
 }

--- a/Simperium/src/main/java/com/simperium/client/RemoteChange.java
+++ b/Simperium/src/main/java/com/simperium/client/RemoteChange.java
@@ -105,28 +105,28 @@ public class RemoteChange {
     protected Ghost apply(Ghost ghost) throws RemoteChangeInvalidException {
         // keys and versions must match otherwise throw an error
         if (!ghost.getSimperiumKey().equals(getKey())) {
-            throw(new RemoteChangeInvalidException(
+            throw(new RemoteChangeInvalidException(this,
                     String.format(Locale.US, "Local instance key %s does not match change key %s",
                         ghost.getSimperiumKey(), getKey())));
         }
 
         if (isModifyOperation() && !ghost.getVersion().equals(getSourceVersion())) {
-            throw(new RemoteChangeInvalidException(
+            throw(new RemoteChangeInvalidException(this,
                     String.format(Locale.US, "Local instance of %s has source version of %d and remote change has %d",
                     getKey(), ghost.getVersion(), getSourceVersion())));
         }
 
         if (isAddOperation() && ghost.getVersion() != 0) {
-            throw(new RemoteChangeInvalidException("Local instance has version greater than 0 with remote add operation"));
+            throw(new RemoteChangeInvalidException(this, "Local instance has version greater than 0 with remote add operation"));
         }
 
         try {
             JSONObject properties = jsondiff.apply(ghost.getDiffableValue(), getPatch());
             return new Ghost(getKey(), getObjectVersion(), properties);
         } catch (JSONException e) {
-            throw new RemoteChangeInvalidException("Unable to apply diff", e);
+            throw new RemoteChangeInvalidException(this, String.format("Unable to apply patch: %s", getPatch()), e);
         } catch (IllegalArgumentException e) {
-            throw new RemoteChangeInvalidException("Invalid patch", e);
+            throw new RemoteChangeInvalidException(this, "Invalid patch", e);
         }
 
     }

--- a/Simperium/src/main/java/com/simperium/client/RemoteChange.java
+++ b/Simperium/src/main/java/com/simperium/client/RemoteChange.java
@@ -13,6 +13,29 @@ import java.util.Locale;
  */
 public class RemoteChange {
 
+    /**
+     * Possible simperium response errors
+     * @see https://gist.github.com/beaucollins/6998802#error-responses
+     */
+    public enum ResponseCode {
+        OK               (200),
+        INVALID_ID       (400),
+        UNAUTHORIZED     (401),
+        NOT_FOUND        (404),
+        INVALID_VERSION  (405),
+        DUPLICATE_CHANGE (409),
+        EMPTY_CHANGE     (412),
+        EXCEEDS_MAX_SIZE (413),
+        INVALID_DIFF     (440);
+
+        public final int code;
+
+        ResponseCode(int code) {
+            this.code = code;
+        }
+
+    }
+
     static public final String TAG = "Simperium.RemoteChange";
 
     public static final String ID_KEY             = "id";
@@ -158,6 +181,10 @@ public class RemoteChange {
         return operation.equals(OPERATION_MODIFY) && (sourceVersion == null || sourceVersion <= 0);
     }
 
+    public ResponseCode getResponseCode() {
+        return responseForCode(getErrorCode());
+    }
+
     public Integer getErrorCode(){
         return errorCode;
     }
@@ -251,6 +278,20 @@ public class RemoteChange {
 
         return new RemoteChange(client_id, id, ccids, changeVersion, sourceVersion, objectVersion, operation, patch);
 
+    }
+
+    public static ResponseCode responseForCode(Integer code) {
+
+        if (code == null)
+            return ResponseCode.OK;
+
+        for (ResponseCode responseCode : ResponseCode.values()) {
+            if (responseCode.code == code) {
+                return responseCode;
+            }
+        }
+
+        return ResponseCode.OK;
     }
 
 }

--- a/Simperium/src/main/java/com/simperium/client/RemoteChange.java
+++ b/Simperium/src/main/java/com/simperium/client/RemoteChange.java
@@ -6,6 +6,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Locale;
+
 /**
  * Encapsulates parsing and logic for remote changes
  */
@@ -81,19 +83,18 @@ public class RemoteChange {
         // keys and versions must match otherwise throw an error
         if (!ghost.getSimperiumKey().equals(getKey())) {
             throw(new RemoteChangeInvalidException(
-                    String.format("Local instance key %s does not match change key %s",
+                    String.format(Locale.US, "Local instance key %s does not match change key %s",
                         ghost.getSimperiumKey(), getKey())));
         }
 
         if (isModifyOperation() && !ghost.getVersion().equals(getSourceVersion())) {
             throw(new RemoteChangeInvalidException(
-                    String.format("Local instance of %s has source version of %d and remote change has %d",
+                    String.format(Locale.US, "Local instance of %s has source version of %d and remote change has %d",
                     getKey(), ghost.getVersion(), getSourceVersion())));
         }
 
         if (isAddOperation() && ghost.getVersion() != 0) {
-            throw(new RemoteChangeInvalidException(
-                    String.format("Local instance has version greater than 0 with remote add operation")));
+            throw(new RemoteChangeInvalidException("Local instance has version greater than 0 with remote add operation"));
         }
 
         try {
@@ -223,9 +224,9 @@ public class RemoteChange {
 
     public String toString(){
         if (!isError()) {
-            return String.format("RemoteChange %s %s %s %d-%d", getKey(), getChangeVersion(), operation, getSourceVersion(), getObjectVersion());
+            return String.format(Locale.US, "RemoteChange %s %s %s %d-%d", getKey(), getChangeVersion(), operation, getSourceVersion(), getObjectVersion());
         } else {
-            return String.format("RemoteChange %s Error %d", getKey(), getErrorCode());
+            return String.format(Locale.US, "RemoteChange %s Error %d", getKey(), getErrorCode());
         }
     }
 

--- a/Simperium/src/main/java/com/simperium/client/RemoteChange.java
+++ b/Simperium/src/main/java/com/simperium/client/RemoteChange.java
@@ -16,7 +16,7 @@ public class RemoteChange {
     public static final String ID_KEY             = "id";
     public static final String CLIENT_KEY         = "clientid";
     public static final String ERROR_KEY          = "error";
-    public static final String ENTITY_VERSION_KEY = "ev";
+    public static final String END_VERSION_KEY    = "ev";
     public static final String SOURCE_VERSION_KEY = "sv";
     public static final String CHANGE_VERSION_KEY = "cv";
     public static final String CHANGE_IDS_KEY     = "ccids";
@@ -244,7 +244,7 @@ public class RemoteChange {
 
         String operation = changeData.getString(OPERATION_KEY);
         Integer sourceVersion = changeData.optInt(SOURCE_VERSION_KEY);
-        Integer objectVersion = changeData.optInt(ENTITY_VERSION_KEY);
+        Integer objectVersion = changeData.optInt(END_VERSION_KEY);
         JSONObject patch = changeData.optJSONObject(VALUE_KEY);
         String changeVersion = changeData.getString(CHANGE_VERSION_KEY);
 

--- a/Simperium/src/main/java/com/simperium/client/RemoteChangeInvalidException.java
+++ b/Simperium/src/main/java/com/simperium/client/RemoteChangeInvalidException.java
@@ -3,8 +3,22 @@ package com.simperium.client;
 import com.simperium.SimperiumException;
 
 public class RemoteChangeInvalidException extends SimperiumException {
-  public RemoteChangeInvalidException() { super(); }
-  public RemoteChangeInvalidException(String message) { super(message); }
-  public RemoteChangeInvalidException(String message, Throwable cause) { super(message, cause); }
-  public RemoteChangeInvalidException(Throwable cause) { super(cause); }
+
+    public final RemoteChange remoteChange;
+
+    public RemoteChangeInvalidException(RemoteChange change, Throwable cause) {
+        super(cause);
+        this.remoteChange = change;
+    }
+
+    public RemoteChangeInvalidException(RemoteChange change, String message) {
+        super(message);
+        this.remoteChange = change;
+    }
+
+    public RemoteChangeInvalidException(RemoteChange change, String message, Throwable cause) {
+        super(message, cause);
+        this.remoteChange = change;
+    }
+
 }

--- a/Simperium/src/main/java/com/simperium/client/Syncable.java
+++ b/Simperium/src/main/java/com/simperium/client/Syncable.java
@@ -2,6 +2,8 @@ package com.simperium.client;
 
 import org.json.JSONObject;
 
+import com.simperium.util.JSONDiff;
+
 /**
  * An object that can be diffed and changes sent
  */
@@ -34,7 +36,7 @@ public abstract class Syncable implements Diffable {
      * Does the local object have modifications?
      */
     public Boolean isModified(){
-        return !getDiffableValue().equals(ghost.getDiffableValue());
+        return !JSONDiff.equals(getDiffableValue(), ghost.getDiffableValue());
     }
 
     public String getBucketName(){

--- a/Simperium/src/main/java/com/simperium/util/JSONDiff.java
+++ b/Simperium/src/main/java/com/simperium/util/JSONDiff.java
@@ -79,7 +79,7 @@ public class JSONDiff {
         int max = Math.max(size_a, size_b);
 
         for (int i=0; i<max; i++) {
-            String index = new Integer(i+prefix_length).toString();
+            String index = String.valueOf(i+prefix_length);
             if(i<size_a && i<size_b){
                 // both lists have index
                 // if values aren't equal add to diff

--- a/Simperium/src/main/java/com/simperium/util/Uuid.java
+++ b/Simperium/src/main/java/com/simperium/util/Uuid.java
@@ -8,5 +8,12 @@ public class Uuid {
         return UUID.randomUUID().toString().replace("-","");
     }
 
+    /**
+     * Take only the specified number of characters from the front of the UUID 
+     */
+    public static String uuid(int length){
+        return uuid().substring(0, length);
+    }
+
 }
 

--- a/Simperium/src/main/res/layout/login.xml
+++ b/Simperium/src/main/res/layout/login.xml
@@ -8,7 +8,7 @@
 
     <LinearLayout
             android:layout_width="@dimen/login_width"
-            android:layout_height="fill_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical"
             android:paddingTop="16dp"
             android:paddingBottom="16dp"

--- a/Simperium/src/main/res/layout/login.xml
+++ b/Simperium/src/main/res/layout/login.xml
@@ -21,7 +21,8 @@
                 android:layout_height="110dp"
                 android:src="@drawable/logo_login"
                 android:layout_marginTop="16dp"
-                android:layout_marginBottom="16dp"/>
+                android:layout_marginBottom="16dp"
+                android:contentDescription="@string/app_name" />
 
         <EditText
                 android:id="@+id/email_address"

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -3,7 +3,6 @@
 
     <!-- account setup -->
     <string name="required_fields">Required Fields</string>
-    <string name="required_field">Required Field</string>
     <string name="username_password_required">Please fill in all of the fields before submitting.</string>
     <string name="invalid_email_title">Invalid email</string>
     <string name="invalid_email_message">Your email address is not valid.</string>
@@ -17,26 +16,17 @@
     <string name="signin_label">Sign In</string>
     <string name="no_network_title">No network available</string>
     <string name="no_network_message">There is no network available. Please connect to a network and try again.</string>
-    <string name="account_setup">Account Setup</string>
-    <string name="signing_up">Signing up...</string>
-    <string name="signing_in">Signing in...</string>
+    <string name="signing_up">Signing up…</string>
+    <string name="signing_in">Signing in…</string>
     <string name="agree_terms_of_service">By signing up, you agree to our <u>Terms of Service.</u></string>
     <string name="login_failed_message">Could not login with the provided email address and password.</string>
     <string name="login_failed_account_exists">An account with this email already exists.</string>
-    <string name="create_account">Create a New Account</string>
     <string name="forgot_password">Forgot your password?</string>
     
     <!-- errors -->
     <string name="error">Error</string>
-    <string name="new_task">New Task</string>
-    <string name="edit_task">Edit Task</string>
-    <string name="delete_task">Delete Task</string>
     <string name="ok">OK</string>
-    <string name="cancel">Cancel</string>
-    <string name="new_task_dialog_title">Add Task</string>
-    <string name="task_label_hint">Describe task</string>
-    <string name="or">or</string>
-    <string name="no_account">Don\'t have an account yet?</string>
+    <string name="no_account">Don’t have an account yet?</string>
     <string name="have_account">Already have an account?</string>
 
 </resources>

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- String to be replaced by application -->
+    <string name="app_name">Simperium</string>
+
     <!-- account setup -->
     <string name="required_fields">Required Fields</string>
     <string name="username_password_required">Please fill in all of the fields before submitting.</string>

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -33,8 +33,8 @@ public class MockChannel implements Bucket.Channel {
         Change change = new Change(Change.OPERATION_REMOVE, object);
         try {
             if(started && autoAcknowledge) acknowledge(change);
-        } catch (RemoteChangeInvalidException e) {
-            throw( new RuntimeException(e));
+        } catch (Exception e) {
+            throw(new RuntimeException(e));
         }
         return change;
     }
@@ -44,7 +44,7 @@ public class MockChannel implements Bucket.Channel {
         Change change = new Change(Change.OPERATION_MODIFY, object);
         try {
             if(started && autoAcknowledge) acknowledge(change);
-        } catch (RemoteChangeInvalidException e) {
+        } catch (Exception e) {
             throw(new RuntimeException(e));
         }
         return change;
@@ -70,7 +70,7 @@ public class MockChannel implements Bucket.Channel {
      * Simulate an acknowledged change
      */
     protected void acknowledge(Change change)
-    throws RemoteChangeInvalidException {
+    throws Exception {
 
         Integer sourceVersion = change.getVersion();
         Integer entityVersion = null;
@@ -82,16 +82,15 @@ public class MockChannel implements Bucket.Channel {
         JSONArray ccids = new JSONArray();
         String cv = Uuid.uuid(0xF);
         ccids.put(change.getChangeId());
+
         RemoteChange ack;
-        try {
-            if (!change.getOperation().equals(Change.OPERATION_REMOVE)) {
-                ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff());
-            } else {
-                ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, Change.OPERATION_REMOVE, null);
-            }
-        } catch (JSONException e) {
-            throw new RemoteChangeInvalidException("Could not make remote chante", e);
+
+        if (!change.getOperation().equals(Change.OPERATION_REMOVE)) {
+            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff());
+        } else {
+            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, Change.OPERATION_REMOVE, null);
         }
+
         Log.d(TAG, String.format("Auto acknowledging %s", ack));
         Log.d(TAG, String.format("Patch: %s", ack.getPatch()));
         ack.isAcknowledgedBy(change);

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -80,7 +80,7 @@ public class MockChannel implements Bucket.Channel {
             entityVersion = sourceVersion + 1;
         }
         JSONArray ccids = new JSONArray();
-        String cv = Uuid.uuid().substring(0, 0xF);
+        String cv = Uuid.uuid(0xF);
         ccids.put(change.getChangeId());
         RemoteChange ack;
         try {

--- a/Simperium/src/support/java/com/simperium/test/MockChannelListener.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannelListener.java
@@ -2,6 +2,7 @@ package com.simperium.test;
 
 import com.simperium.client.Channel;
 import com.simperium.util.Uuid;
+import com.simperium.util.ChannelUtil;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -65,32 +66,7 @@ public class MockChannelListener implements Channel.OnMessageListener {
         }
 
         if (autoAcknowledge == true && message.isCommand(Channel.COMMAND_CHANGE)) {
-            try {
-                Channel channel = (Channel) event.getSource();
-                JSONObject changeJSON = new JSONObject(event.message.substring(2));
-                JSONObject ackJSON = new JSONObject();
-                JSONArray ccids = new JSONArray();
-                ccids.put(changeJSON.get("ccid"));
-                ackJSON.put("clientid", channel.getSessionId());
-                ackJSON.put("id", changeJSON.getString("id"));
-                ackJSON.put("o", changeJSON.getString("o"));
-                ackJSON.put("v", changeJSON.getJSONObject("v"));
-                ackJSON.put("ccids", ccids);
-                ackJSON.put("cv", Uuid.uuid());
-                int sv = -1;
-                if (changeJSON.has("sv")) {
-                    sv = changeJSON.getInt("sv");
-                    ackJSON.put("sv", changeJSON.getInt("sv"));
-                }
-                ackJSON.put("ev", sv + 1);
-
-                JSONArray responseJSON = new JSONArray();
-                responseJSON.put(ackJSON);
-                Log.d(TAG, String.format("Sending auto-acknowledge response: %s", responseJSON));
-                channel.receiveMessage(String.format("c:%s", responseJSON));
-            } catch (JSONException e) {
-                throw new RuntimeException(String.format("Couldn't auto-acknowledge %s", event.message), e);
-            }
+            ChannelUtil.acknowledgeChange(event);
         }
 
         lastMessage = event;

--- a/Simperium/src/support/java/com/simperium/test/MockExecutor.java
+++ b/Simperium/src/support/java/com/simperium/test/MockExecutor.java
@@ -1,5 +1,6 @@
 package com.simperium.test;
 
+import java.util.Locale;
 import java.util.concurrent.Executor;
 
 import java.util.ArrayList;
@@ -30,7 +31,7 @@ public class MockExecutor {
         @Override
         public String toString(){
             String status = mPaused ? "paused" : "playing";
-            return String.format("MockExecutor.Playable %s (pending: %d)", status, pending.size());
+            return String.format(Locale.US, "MockExecutor.Playable %s (pending: %d)", status, pending.size());
         }
 
         @Override
@@ -38,7 +39,7 @@ public class MockExecutor {
             if (!mPaused) {
                 runnable.run();
             } else {
-                Log.d(TAG, String.format("Queuing runnable %s", runnable));
+                Log.d(TAG, String.format(Locale.US, "Queuing runnable %s", runnable));
                 pending.add(runnable);
             }
         }

--- a/Simperium/src/support/java/com/simperium/util/ChannelUtil.java
+++ b/Simperium/src/support/java/com/simperium/util/ChannelUtil.java
@@ -1,0 +1,29 @@
+package com.simperium.util;
+
+import com.simperium.client.Channel;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+public class ChannelUtil {
+
+    public static void acknowledgeChange(Channel.MessageEvent event) {
+
+        try {
+            JSONArray responseJSON = RemoteChangesUtil.acknowledgeChange(event);
+            event.channel.receiveMessage(String.format("c:%s", responseJSON));
+        } catch (JSONException e) {
+            throw new RuntimeException(String.format("Couldn't auto-acknowledge %s", event.message), e);
+        }
+
+    }
+
+    public static void sendModifyOperation(Channel channel, String objectId) {
+
+        
+
+    }
+
+
+}

--- a/Simperium/src/support/java/com/simperium/util/ChannelUtil.java
+++ b/Simperium/src/support/java/com/simperium/util/ChannelUtil.java
@@ -19,9 +19,14 @@ public class ChannelUtil {
 
     }
 
-    public static void sendModifyOperation(Channel channel, String objectId) {
+    public static void sendModifyOperation(Channel channel, String objectId, int sourceVersion, JSONObject diff) {
 
-        
+        try {
+            JSONObject modify = RemoteChangesUtil.modifyOperation(objectId, sourceVersion, diff);
+            channel.receiveMessage(String.format("c:[%s]", modify));
+        } catch (JSONException e) {
+            throw new RuntimeException("Could not build change", e);
+        }
 
     }
 

--- a/Simperium/src/support/java/com/simperium/util/ChannelUtil.java
+++ b/Simperium/src/support/java/com/simperium/util/ChannelUtil.java
@@ -6,6 +6,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
 
+import java.util.Locale;
+
 public class ChannelUtil {
 
     public static void acknowledgeChange(Channel.MessageEvent event) {
@@ -30,5 +32,14 @@ public class ChannelUtil {
 
     }
 
+    public static void sendObject(Channel channel, String id, int version, JSONObject data) {
+        try {
+            JSONObject payload = new JSONObject();
+            payload.put("data", data);
+            channel.receiveMessage(String.format(Locale.US, "e:%s.%d\n%s", id, version, payload));
+        } catch (JSONException e) {
+            throw new RuntimeException("Could not send object data", e);
+        }
+    }
 
 }

--- a/Simperium/src/support/java/com/simperium/util/RemoteChangesUtil.java
+++ b/Simperium/src/support/java/com/simperium/util/RemoteChangesUtil.java
@@ -1,0 +1,102 @@
+package com.simperium.util;
+
+import com.simperium.client.Change;
+import com.simperium.client.Channel;
+import com.simperium.client.RemoteChange;
+
+import com.simperium.util.JSONDiff;
+import com.simperium.util.Uuid;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+public class RemoteChangesUtil {
+
+    public static JSONObject operation(String id, String client, String cv, String ccid)
+    throws JSONException {
+
+        JSONObject change = new JSONObject();
+        change.put(RemoteChange.CHANGE_IDS_KEY, new JSONArray("[\"" + ccid + "\"]"));
+        change.put(RemoteChange.CLIENT_KEY, client);
+        change.put(RemoteChange.CHANGE_VERSION_KEY, cv);
+        change.put(RemoteChange.ID_KEY, id);
+
+        return change;
+    }
+
+    public static JSONObject operation(String id, String client, String changeId)
+    throws JSONException {
+        return operation(id, client, Uuid.uuid(), changeId);
+    }
+
+    public static JSONObject operation(String id, String client)
+    throws JSONException {
+        return operation(id, client, Uuid.uuid());
+    }
+
+    public static JSONObject operation(String id)
+    throws JSONException {
+        return operation(id, "mock-client");
+    }
+
+    /**
+     * Generate a delete operation for they give object id with a random ccid
+     * and cv.
+     */
+    public static JSONObject deleteOperation(String id)
+    throws JSONException {
+        
+        JSONObject change = operation(id);
+        change.put(RemoteChange.OPERATION_KEY, RemoteChange.OPERATION_REMOVE);
+
+        return change;
+
+    }
+
+    public static JSONObject addOperation(String id)
+    throws JSONException {
+        JSONObject change = operation(id);
+        change.put(RemoteChange.OPERATION_KEY, RemoteChange.OPERATION_MODIFY);
+        return change;
+    }
+
+    public static JSONObject modifyOperation(String id, int sourceVersion)
+    throws JSONException {
+        JSONObject change = addOperation(id);
+        return change;
+    }
+
+    public static JSONArray acknowledgeChange(Channel.MessageEvent channelEvent)
+    throws JSONException {
+        JSONObject change = new JSONObject(channelEvent.message.substring(2));
+        return acknowledgeChange(change, channelEvent.channel);
+    }
+
+    public static JSONArray acknowledgeChange(JSONObject change, Channel channel)
+    throws JSONException {
+
+        String id = change.getString(Change.ID_KEY);
+        String client = channel.getSessionId();
+        String ccid = change.getString(Change.CHANGE_ID_KEY);
+
+        JSONObject ack = operation(id, client, ccid);
+        ack.put(RemoteChange.OPERATION_KEY, change.getString(Change.OPERATION_KEY));
+        ack.put(JSONDiff.DIFF_VALUE_KEY, change.getJSONObject(JSONDiff.DIFF_VALUE_KEY));
+
+        int sv = -1;
+
+        if (change.has(RemoteChange.SOURCE_VERSION_KEY)) {
+            sv = change.getInt(RemoteChange.SOURCE_VERSION_KEY);
+            ack.put(RemoteChange.SOURCE_VERSION_KEY, change.getInt(RemoteChange.SOURCE_VERSION_KEY));
+        }
+
+        ack.put(RemoteChange.END_VERSION_KEY, sv + 1);
+
+        JSONArray response = new JSONArray();
+        response.put(ack);
+
+        return response;
+    }
+
+}

--- a/Simperium/src/support/java/com/simperium/util/RemoteChangesUtil.java
+++ b/Simperium/src/support/java/com/simperium/util/RemoteChangesUtil.java
@@ -61,9 +61,13 @@ public class RemoteChangesUtil {
         return change;
     }
 
-    public static JSONObject modifyOperation(String id, int sourceVersion)
+    public static JSONObject modifyOperation(String id, int sourceVersion, JSONObject diff)
     throws JSONException {
         JSONObject change = addOperation(id);
+        change.put(RemoteChange.SOURCE_VERSION_KEY, sourceVersion);
+        change.put(RemoteChange.END_VERSION_KEY, sourceVersion + 1);
+        change.put(JSONDiff.DIFF_VALUE_KEY, diff);
+
         return change;
     }
 

--- a/SimperiumIntegrationTests/src/instrumentTest/java/com/simperium/testapp/BasicTest.java
+++ b/SimperiumIntegrationTests/src/instrumentTest/java/com/simperium/testapp/BasicTest.java
@@ -23,7 +23,7 @@ public class BasicTest extends SimperiumTest {
     protected void setUp() throws Exception {
         super.setUp();
         clients = createClients(3);
-        String bucketSuffix = Uuid.uuid().substring(0,6);
+        String bucketSuffix = Uuid.uuid(6);
         buckets = createAndStartBuckets(clients, new Farm.Schema(bucketSuffix));
         leader = buckets.get(0);
     }

--- a/SimperiumIntegrationTests/src/instrumentTest/java/com/simperium/testapp/ComplexTest.java
+++ b/SimperiumIntegrationTests/src/instrumentTest/java/com/simperium/testapp/ComplexTest.java
@@ -23,7 +23,7 @@ public class ComplexTest extends SimperiumTest {
     protected void setUp() throws Exception {
         super.setUp();
         clients = createClients(3);
-        String bucketSuffix = Uuid.uuid().substring(0,6);
+        String bucketSuffix = Uuid.uuid(6);
         buckets = createAndStartBuckets(clients, new Farm.Schema(bucketSuffix));
         leader = buckets.get(0);
     }


### PR DESCRIPTION
If the client cannot apply a remote change it should download the entire object from the server.
