### PR TITLE
Reset any previously used timer

### DIFF
--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -1378,6 +1378,7 @@ public class Channel implements Bucket.Channel {
                 pendingChanges.put(localChange.getKey(), localChange);
                 sendChange(localChange);
                 localChange.setOnRetryListener(this);
+                localChange.resetTimer();
                 retryTimer.scheduleAtFixedRate(localChange.getRetryTimer(),
                     RETRY_DELAY_MS, RETRY_DELAY_MS);                
             } catch (ChangeNotSentException e) {


### PR DESCRIPTION
To prevent rescheduling already used timers, cancel existing timers.
