### PR TITLE
Fire a bucket listener message after the bucket resets.

### DIFF
--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -77,7 +77,7 @@ public class Bucket<T extends Syncable> {
     }
 
     public enum ChangeType {
-        REMOVE, MODIFY, INDEX
+        REMOVE, MODIFY, INDEX, RESET
     }
 
     public static final String TAG="Simperium.Bucket";
@@ -651,10 +651,12 @@ public class Bucket<T extends Syncable> {
 
     public void reset(){
         storage.reset();
+        // Clear the ghost store
         ghostStore.resetBucket(this);
         channel.reset();
         stop();
-        // Clear the ghost store
+
+        notifyOnNetworkChangeListeners(ChangeType.RESET);
     }
     /**
      * Does bucket have at least the requested version?


### PR DESCRIPTION
- Adds a RESET value to the ChangeType enum
- Trigger the listener with the RESET value after the bucket resets.

Allows for clients to react accordingly if the bucket resets.
