### PR TITLE
Issue/112 duplicate changes

### DIFF
--- a/Simperium/src/androidTest/java/com/simperium/BucketTest.java
+++ b/Simperium/src/androidTest/java/com/simperium/BucketTest.java
@@ -176,4 +176,28 @@ public class BucketTest extends TestCase {
 
     }
 
+    public void testMergeLocalChangesWithUpdatedGhost()
+            throws Exception {
+
+        Note note = mBucket.newObject();
+
+        note.setContent("Line 1\n");
+        note.save();
+
+        // make a local modification before remote change comes in
+        note.setContent("Line 1\nLine 3\n");
+
+        // create a 3rd party modification
+        JSONObject external = new JSONObject(note.getDiffableValue().toString());
+        external.put("content", "Line 1\nLine 2\n");
+
+        // build remote change based on 3rd party modification
+        RemoteChange change = RemoteChangesUtil.buildRemoteChange(note, external);
+        Ghost ghost = change.apply(note.getGhost());
+
+        mBucket.updateGhost(ghost, null);
+
+        assertEquals("Line 1\nLine 2\nLine 3\n", note.getContent());
+    }
+
 }

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -453,8 +453,7 @@ public class Bucket<T extends Syncable> {
         ghostStore.saveGhost(Bucket.this, ghost);
 
         // Update this object if exists in cache, otherwise build it
-        T object;
-        object = cache.get(ghost.getSimperiumKey());
+        T object = cache.get(ghost.getSimperiumKey());
         if (object != null) {
             schema.update(object, ghost.getDiffableValue());
         } else {

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -1364,6 +1364,8 @@ public class Channel implements Bucket.Channel {
         }
 
         private void dequeueLocalChangesForKey(String simperiumKey) {
+            if (simperiumKey == null) return;
+
             Iterator<Change> iterator = localQueue.iterator();
             while (iterator.hasNext()) {
                 Change queuedChange = iterator.next();

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -1331,6 +1331,10 @@ public class Channel implements Bucket.Channel {
                             } catch (RemoteChangeInvalidException e){
                                 Logger.log(TAG, "Remote change could not be acknowledged", e);
                                 log(LOG_DEBUG, String.format("Failed to acknowledge change <%s> Reason: %s", remoteChange.getChangeVersion(), e.getMessage()));
+
+                                // request the full object for the new version
+                                ObjectVersion version = new ObjectVersion(remoteChange.getKey(), remoteChange.getObjectVersion());
+                                sendMessage(String.format("%s:%s", COMMAND_ENTITY, version));
                             }
                         }
                     } else {


### PR DESCRIPTION
`Channel` will now request the full object if it is unable to apply an acknowledged remote change, and it will also remove any local changes for the same object.

`Bucket` can now check for local modifications when it is applying the full object that was requested. It will save the ghost even if it can't merge the changes, to make sure we have the latest SV and won't send duplicate changes back to Simperium.

Also added a new test that tests the full object merge with local modifications.
