### PR TITLE
Fix #116 duplicate object returned in DB Query

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/PersistentStore.java
+++ b/Simperium/src/main/java/com/simperium/android/PersistentStore.java
@@ -66,6 +66,10 @@ public class PersistentStore implements StorageProvider {
         @Override
         public void prepare(Bucket<T> bucket){
             setupFullText();
+
+            // Clear reindex table to stop any other indexing operations
+            database.delete(REINDEX_QUEUE_TABLE, "bucket=?", new String[]{bucketName});
+
             reindex(bucket);
         }
 
@@ -446,7 +450,7 @@ public class PersistentStore implements StorageProvider {
             String bucketName = mDataStore.bucketName;
             String ftName = mDataStore.getFullTextTableName();
 
-            selection = new StringBuilder("SELECT objects.rowid AS `_id`, objects.bucket || objects.key AS `key`, objects.key as `object_key`, objects.data as `object_data` ");
+            selection = new StringBuilder("SELECT DISTINCT objects.rowid AS `_id`, objects.bucket || objects.key AS `key`, objects.key as `object_key`, objects.data as `object_data` ");
             StringBuilder filters = new StringBuilder();
             StringBuilder where = new StringBuilder("WHERE objects.bucket = ?");
 


### PR DESCRIPTION
Clear out index_requeue table before we start a reindex, which will stop other index operations for the same bucket.

Added `DISTINCT` to compileQuery() so we are getting unique rows per Simperium key.

Fixes #116
