### PR TITLE
Throw `ChangeNotSentException` when we catch a `ChangeEmptyException`

### DIFF
--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -1455,6 +1455,7 @@ public class Channel implements Bucket.Channel {
                 change.setSent();
             } catch (ChangeEmptyException e) {
                 completeAndDequeueChange(change);
+                throw new ChangeNotSentException(change, e);
             } catch (ChangeException e) {
                 android.util.Log.e(TAG, "Could not send change", e);
                 throw new ChangeNotSentException(change, e);


### PR DESCRIPTION
Throw `ChangeNotSentException` when we catch a `ChangeEmptyException`, which will remove the change from the queue.

Fixes #120.
