### PR TITLE
Fix #128: Create Change diff against latest Ghost

### DIFF
--- a/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
@@ -3,6 +3,7 @@ package com.simperium;
 import com.simperium.client.Change;
 import com.simperium.client.Bucket;
 import com.simperium.client.Syncable;
+import com.simperium.client.Ghost;
 
 import com.simperium.models.Note;
 
@@ -31,10 +32,12 @@ public class ChangeTest extends TestCase {
 
         Change change = new Change(Change.OPERATION_MODIFY, mNote);
 
+        Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());
         assertTrue(change.isModifyOperation());
-        assertValidChangeObject(mNote, change);
+        assertValidChangeObject(mNote, ghost, change);
 
-        JSONObject diff = change.toJSONObject().getJSONObject("v");
+
+        JSONObject diff = change.toJSONObject(ghost).getJSONObject("v");
 
         String expected = "{\"tags\":{\"v\":[],\"o\":\"+\"},\"deleted\":{\"v\":false,\"o\":\"+\"},\"title\":{\"v\":\"Hello world\",\"o\":\"+\"}}";
         assertEquals(expected, diff.toString());
@@ -47,9 +50,9 @@ public class ChangeTest extends TestCase {
         mNote.save();
 
         Change change = new Change(Change.OPERATION_REMOVE, mNote);
-
+        Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());
         assertTrue(change.isRemoveOperation());
-        assertValidChangeObject(mNote, change);
+        assertValidChangeObject(mNote, ghost, change);
 
     }
 
@@ -59,14 +62,15 @@ public class ChangeTest extends TestCase {
         Change change = new Change(Change.OPERATION_MODIFY, mNote);
         change.setSendFullObject(true);
 
-        assertValidChangeObject(mNote, change);
-        assertEquals(mNote.getDiffableValue().toString(), change.toJSONObject().getJSONObject("d").toString());
+        Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());
+        assertValidChangeObject(mNote, ghost, change);
+        assertEquals(mNote.getDiffableValue().toString(), change.toJSONObject(ghost).getJSONObject("d").toString());
     }
 
-    public static void assertValidChangeObject(Syncable object, Change change)
+    public static void assertValidChangeObject(Syncable object, Ghost ghost, Change change)
     throws Exception {
 
-        JSONObject changeJSON = change.toJSONObject();
+        JSONObject changeJSON = change.toJSONObject(ghost);
 
         assertNotNull("Change missing ccid", changeJSON.optString("ccid"));
         assertNotNull("Change missing operation key `o`", changeJSON.optString("o"));

--- a/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
@@ -33,11 +33,12 @@ public class ChangeTest extends TestCase {
         Change change = new Change(Change.OPERATION_MODIFY, mNote);
 
         Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());
+        JSONObject object = mNote.getDiffableValue();
         assertTrue(change.isModifyOperation());
         assertValidChangeObject(mNote, ghost, change);
 
 
-        JSONObject diff = change.toJSONObject(ghost).getJSONObject("v");
+        JSONObject diff = change.toJSONObject(object, ghost).getJSONObject("v");
 
         String expected = "{\"tags\":{\"v\":[],\"o\":\"+\"},\"deleted\":{\"v\":false,\"o\":\"+\"},\"title\":{\"v\":\"Hello world\",\"o\":\"+\"}}";
         assertEquals(expected, diff.toString());
@@ -63,14 +64,15 @@ public class ChangeTest extends TestCase {
         change.setSendFullObject(true);
 
         Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());
+        JSONObject object = mNote.getDiffableValue();
         assertValidChangeObject(mNote, ghost, change);
-        assertEquals(mNote.getDiffableValue().toString(), change.toJSONObject(ghost).getJSONObject("d").toString());
+        assertEquals(mNote.getDiffableValue().toString(), change.toJSONObject(object, ghost).getJSONObject("d").toString());
     }
 
     public static void assertValidChangeObject(Syncable object, Ghost ghost, Change change)
     throws Exception {
 
-        JSONObject changeJSON = change.toJSONObject(ghost);
+        JSONObject changeJSON = change.toJSONObject(object.getDiffableValue(), ghost);
 
         assertNotNull("Change missing ccid", changeJSON.optString("ccid"));
         assertNotNull("Change missing operation key `o`", changeJSON.optString("o"));

--- a/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
@@ -481,7 +481,6 @@ public class ChannelTest extends BaseSimperiumTest {
         assertEquals(Version.NUMBER, index.getJSONObject("extra").getString("version"));
 
         assertEquals("mock1", index.getJSONArray("pending").getJSONObject(0).getString("id"));
-        assertEquals(1, index.getJSONArray("pending").getJSONObject(0).getInt("sv"));
     }
 
     public void testSendLog()

--- a/Simperium/src/main/java/com/simperium/android/QueueSerializer.java
+++ b/Simperium/src/main/java/com/simperium/android/QueueSerializer.java
@@ -84,14 +84,12 @@ public class QueueSerializer implements Channel.Serializer {
             int statusColumn = items.getColumnIndexOrThrow(FIELD_STATUS);
             int versionColumn = items.getColumnIndexOrThrow(FIELD_VERSION);
             int operationColumn = items.getColumnIndexOrThrow(FIELD_OPERATION);
-            int originColumn = items.getColumnIndexOrThrow(FIELD_ORIGIN);
             int targetColumn = items.getColumnIndexOrThrow(FIELD_TARGET);
             int ccidColumn = items.getColumnIndexOrThrow(FIELD_CCID);
 
             String key;
             String operation;
             String status;
-            JSONObject origin;
             JSONObject target;
 
             while(items.moveToNext()){
@@ -101,15 +99,13 @@ public class QueueSerializer implements Channel.Serializer {
                     status = items.getString(statusColumn);
 
                     if (operation.equals(Change.OPERATION_MODIFY)) {
-                        origin = new JSONObject(items.getString(originColumn));
                         target = new JSONObject(items.getString(targetColumn));
                     } else {
-                        origin = null;
                         target = null;
                     }
 
                     Change change = Change.buildChange(operation, items.getString(ccidColumn),
-                        items.getString(bucketColumn), key, items.getInt(versionColumn), origin, target);
+                        items.getString(bucketColumn), key, items.getInt(versionColumn), target);
 
                     if (status.equals(Status.QUEUED.toString())) {
                         queue.queued.add(change);
@@ -168,7 +164,6 @@ public class QueueSerializer implements Channel.Serializer {
         values.put(FIELD_OPERATION, change.getOperation());
         values.put(FIELD_CCID, change.getChangeId());
         if (change.isModifyOperation()) {
-            values.put(FIELD_ORIGIN, change.getOrigin().toString());
             values.put(FIELD_TARGET, change.getTarget().toString());
         }
 

--- a/Simperium/src/main/java/com/simperium/android/QueueSerializer.java
+++ b/Simperium/src/main/java/com/simperium/android/QueueSerializer.java
@@ -82,7 +82,6 @@ public class QueueSerializer implements Channel.Serializer {
             int bucketColumn = items.getColumnIndexOrThrow(FIELD_BUCKET);
             int keyColumn = items.getColumnIndexOrThrow(FIELD_KEY);
             int statusColumn = items.getColumnIndexOrThrow(FIELD_STATUS);
-            int versionColumn = items.getColumnIndexOrThrow(FIELD_VERSION);
             int operationColumn = items.getColumnIndexOrThrow(FIELD_OPERATION);
             int targetColumn = items.getColumnIndexOrThrow(FIELD_TARGET);
             int ccidColumn = items.getColumnIndexOrThrow(FIELD_CCID);
@@ -105,7 +104,7 @@ public class QueueSerializer implements Channel.Serializer {
                     }
 
                     Change change = Change.buildChange(operation, items.getString(ccidColumn),
-                        items.getString(bucketColumn), key, items.getInt(versionColumn), target);
+                        items.getString(bucketColumn), key, target);
 
                     if (status.equals(Status.QUEUED.toString())) {
                         queue.queued.add(change);
@@ -160,7 +159,6 @@ public class QueueSerializer implements Channel.Serializer {
         values.put(FIELD_BUCKET, change.getBucketName());
         values.put(FIELD_KEY, change.getKey());
         values.put(FIELD_STATUS, status.toString());
-        values.put(FIELD_VERSION, change.getVersion());
         values.put(FIELD_OPERATION, change.getOperation());
         values.put(FIELD_CCID, change.getChangeId());
         if (change.isModifyOperation()) {

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -516,7 +516,7 @@ public class Bucket<T extends Syncable> {
         });
     }
 
-    protected Ghost getGhost(String key) throws GhostMissingException {
+    public Ghost getGhost(String key) throws GhostMissingException {
         return mGhostStore.getGhost(this, key);
     }
     /**

--- a/Simperium/src/main/java/com/simperium/client/Change.java
+++ b/Simperium/src/main/java/com/simperium/client/Change.java
@@ -193,7 +193,7 @@ public class Change {
         this.sendFullObject = sendFullObject;
     }
 
-    public JSONObject toJSONObject()
+    public JSONObject toJSONObject(Ghost ghost)
     throws ChangeEmptyException, ChangeInvalidException {
         try {
             JSONObject json = new JSONObject();
@@ -206,7 +206,7 @@ public class Change {
                 json.put(SOURCE_VERSION_KEY, version);
             }
 
-            JSONObject diff = getDiff();
+            JSONObject diff = getDiff(ghost);
             boolean requiresDiff = requiresDiff();
 
             if (requiresDiff && diff.length() == 0) {
@@ -241,7 +241,7 @@ public class Change {
             props.put(TARGET_KEY, target);
         }
         return props;
-        
+
     }
 
     public void setOnAcknowledgedListener(OnAcknowledgedListener listener){
@@ -249,7 +249,7 @@ public class Change {
     }
 
     public void setOnCompleteListener(OnCompleteListener listener){
-        
+
     }
 
     public Integer getRetryCount() {
@@ -294,9 +294,10 @@ public class Change {
         return operation.equals(OPERATION_MODIFY);
     }
 
-    public JSONObject getDiff(){
+    public JSONObject getDiff(Ghost ghost){
         try {
-            return jsondiff.diff(origin, target);
+            JSONObject ghostObject = ghost.getDiffableValue();
+            return jsondiff.diff(ghostObject, target);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/Simperium/src/main/java/com/simperium/client/Change.java
+++ b/Simperium/src/main/java/com/simperium/client/Change.java
@@ -41,7 +41,6 @@ public class Change {
     private String operation;
     private String key, bucketName;
     private Integer version;
-    private JSONObject origin;
     private JSONObject target;
     private String ccid;
     private boolean pending = true, acknowledged = false, sent = false;
@@ -64,41 +63,29 @@ public class Change {
             object.getBucketName(),
             object.getSimperiumKey(),
             properties.getInt(SOURCE_VERSION_KEY),
-            properties.getJSONObject(ORIGIN_KEY),
             properties.getJSONObject(TARGET_KEY)
         );
     }
 
-    public static Change buildChange(String operation, String ccid, String bucketName, String key, Integer version, JSONObject origin, JSONObject target){
-        return new Change(operation, ccid, bucketName, key, version, origin, target);
-    }
-
-    private Change(String operation, Syncable object, JSONObject origin){
-        this(operation, object.getBucketName(), object.getSimperiumKey(), object.getVersion(),
-            origin, object.getDiffableValue());
-    }
-
-    private Change(String operation, String bucketName, String key, Integer sourceVersion, JSONObject origin, JSONObject target, Change compressed){
-        this(operation, bucketName, key, sourceVersion, origin, target);
-        this.compressed = compressed;
+    public static Change buildChange(String operation, String ccid, String bucketName, String key, Integer version, JSONObject target){
+        return new Change(operation, ccid, bucketName, key, version, target);
     }
 
     public Change(String operation, Syncable object){
-        this(operation, object, object.getUnmodifiedValue());
+        this(operation, object.getBucketName(), object.getSimperiumKey(), object.getVersion(), object.getDiffableValue());
     }
 
-    protected Change(String operation, String bucketName, String key, Integer sourceVersion, JSONObject origin, JSONObject target){
-        this(operation, uuid(), bucketName, key, sourceVersion, origin, target);
+    protected Change(String operation, String bucketName, String key, Integer sourceVersion, JSONObject target){
+        this(operation, uuid(), bucketName, key, sourceVersion, target);
     }
 
-    protected Change(String operation, String ccid, String bucketName, String key, Integer sourceVersion, JSONObject origin, JSONObject target){
+    protected Change(String operation, String ccid, String bucketName, String key, Integer sourceVersion, JSONObject target){
         this.operation = operation;
         this.ccid = ccid;
         this.bucketName = bucketName;
         this.key = key;
         if (!operation.equals(OPERATION_REMOVE)) {
             this.version = sourceVersion;
-            this.origin = JSONDiff.deepCopy(origin);
             this.target = JSONDiff.deepCopy(target);
         }
 
@@ -173,10 +160,6 @@ public class Change {
         return this.ccid;
     }
 
-    public JSONObject getOrigin(){
-        return origin;
-    }
-
     public JSONObject getTarget(){
         return target;
     }
@@ -187,6 +170,10 @@ public class Change {
 
     public Integer getVersion(){
         return version;
+    }
+
+    public void setVersion(Integer serverVersion) {
+        version = serverVersion;
     }
 
     public void setSendFullObject(boolean sendFullObject) {
@@ -201,7 +188,6 @@ public class Change {
             json.put(CHANGE_ID_KEY, getChangeId());
             json.put(JSONDiff.DIFF_OPERATION_KEY, getOperation());
 
-            Integer vresion = getVersion();
             if (version != null && version > 0) {
                 json.put(SOURCE_VERSION_KEY, version);
             }
@@ -237,7 +223,6 @@ public class Change {
             props.put(SOURCE_VERSION_KEY, version);
         }
         if (operation.equals(OPERATION_MODIFY)) {
-            props.put(ORIGIN_KEY, origin);
             props.put(TARGET_KEY, target);
         }
         return props;
@@ -302,13 +287,4 @@ public class Change {
             throw new RuntimeException(e);
         }
     }
-
-    /**
-     * Creates a new change with the given sourceVersion and origin
-     */
-    protected Change reapplyOrigin(Integer sourceVersion, JSONObject origin){
-        // protected Change(String operation, String key, Integer sourceVersion, Map<String,Object> origin, Map<String,Object> target){
-        return new Change(operation, bucketName, key, sourceVersion, origin, target, this);
-    }
-
 }

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -1480,9 +1480,9 @@ public class Channel implements Bucket.Channel {
 
             try {
                 log(LOG_DEBUG, String.format("Sending change for id: %s op: %s ccid: %s", change.getKey(), change.getOperation(), change.getChangeId()));
-                Object object = mBucket.getObject(change.getKey());
+                Syncable target = mBucket.getObject(change.getKey());
                 Ghost ghost = mBucket.getGhost(change.getKey());
-                sendMessage(String.format("c:%s", change.toJSONObject(ghost)));
+                sendMessage(String.format("c:%s", change.toJSONObject(target.getDiffableValue(), ghost)));
                 mSerializer.onSendChange(change);
                 change.setSent();
             } catch (BucketObjectMissingException e) {

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -86,7 +86,7 @@ public class MockChannel implements Bucket.Channel {
         RemoteChange ack;
 
         if (!change.getOperation().equals(Change.OPERATION_REMOVE)) {
-            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff(null));
+            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, null);
         } else {
             ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, Change.OPERATION_REMOVE, null);
         }

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -75,7 +75,7 @@ public class MockChannel implements Bucket.Channel {
     throws Exception {
 
         Integer sourceVersion = mBucket.getObject(change.getKey()).getVersion();
-        Integer entityVersion = null;
+        Integer entityVersion;
         if (sourceVersion == null) {
             entityVersion = 1;
         } else {
@@ -89,7 +89,8 @@ public class MockChannel implements Bucket.Channel {
 
         if (!change.getOperation().equals(Change.OPERATION_REMOVE)) {
             Ghost ghost = mBucket.getGhost(change.getKey());
-            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff(ghost));
+            JSONObject object = mBucket.getObject(change.getKey()).getDiffableValue();
+            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff(object, ghost));
         } else {
             ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, Change.OPERATION_REMOVE, null);
         }

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -86,7 +86,7 @@ public class MockChannel implements Bucket.Channel {
         RemoteChange ack;
 
         if (!change.getOperation().equals(Change.OPERATION_REMOVE)) {
-            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff());
+            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff(null));
         } else {
             ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, Change.OPERATION_REMOVE, null);
         }

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -5,6 +5,7 @@ package com.simperium.test;
 
 import com.simperium.client.Bucket;
 import com.simperium.client.Change;
+import com.simperium.client.Ghost;
 import com.simperium.client.RemoteChange;
 import com.simperium.client.RemoteChangeInvalidException;
 import com.simperium.client.Syncable;
@@ -14,6 +15,7 @@ import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 public class MockChannel implements Bucket.Channel {
 
@@ -72,7 +74,7 @@ public class MockChannel implements Bucket.Channel {
     protected void acknowledge(Change change)
     throws Exception {
 
-        Integer sourceVersion = change.getVersion();
+        Integer sourceVersion = mBucket.getObject(change.getKey()).getVersion();
         Integer entityVersion = null;
         if (sourceVersion == null) {
             entityVersion = 1;
@@ -86,7 +88,8 @@ public class MockChannel implements Bucket.Channel {
         RemoteChange ack;
 
         if (!change.getOperation().equals(Change.OPERATION_REMOVE)) {
-            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, null);
+            Ghost ghost = mBucket.getGhost(change.getKey());
+            ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, change.getDiff(ghost));
         } else {
             ack = new RemoteChange("fake", change.getKey(), ccids, cv, sourceVersion, entityVersion, Change.OPERATION_REMOVE, null);
         }


### PR DESCRIPTION
Removed `origin`, `target` and `version` properties from `Change`. Instead of storing these in the Change we now pass the object and its ghost when creating the diff in `Change.toJSONObject()`.

This ensures that the diff being sent up is always against the latest version that we have a SV for.
