### PR TITLE
Explicitly call onDisconnect after disconnecting the socket

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
+++ b/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
@@ -187,6 +187,7 @@ public class WebSocketManager implements ChannelProvider, Channel.OnMessageListe
             Logger.log(TAG, "Disconnecting");
             // being told to disconnect so don't automatically reconnect
             mConnection.close();
+            onDisconnect(null);
         }
     }
 


### PR DESCRIPTION
Tells all listening channels that they are disconnected from the socket.

Fixes #130
