### PR TITLE
If we weren't able to retrieve the object/ghost for a change, dequeue it

### DIFF
--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -1491,9 +1491,11 @@ public class Channel implements Bucket.Channel {
                 change.setSent();
             } catch (BucketObjectMissingException e) {
                 Logger.log("Could not get object to send change");
+                completeAndDequeueChange(change);
                 throw new ChangeNotSentException(change, e);
             } catch (GhostMissingException e) {
                 Logger.log("Could not get ghost to send change");
+                completeAndDequeueChange(change);
                 throw new ChangeNotSentException(change, e);
             } catch (ChangeEmptyException e) {
                 completeAndDequeueChange(change);


### PR DESCRIPTION
I introduced a bug in 593b82866f94439be69836f9ab608c7c13ac2a53 that caused changes to be retried in a loop.
