### PR TITLE
Call websocket methods from main thread

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
+++ b/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
@@ -8,6 +8,7 @@ import com.koushikdutta.async.http.AsyncHttpClient.WebSocketConnectCallback;
 import com.koushikdutta.async.http.WebSocket;
 
 import android.net.Uri;
+import android.os.Handler;
 
 import java.io.IOException;
 
@@ -18,6 +19,7 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
     protected final String mAppId;
     protected final String mSessionId;
     protected final AsyncHttpClient mAsyncClient;
+    protected final Handler mHandler = new Handler();
 
     AsyncWebSocketProvider(String appId, String sessionId, AsyncHttpClient asyncClient) {
         mAppId = appId;
@@ -52,12 +54,26 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
 
                     @Override
                     public void close() {
-                        webSocket.close();
+                        mHandler.post(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                webSocket.close();
+                            }
+
+                        });
                     }
 
                     @Override
-                    public void send(String message) {
-                        webSocket.send(message);
+                    public void send(final String message) {
+                        mHandler.post(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                webSocket.send(message);
+                            }
+
+                        });
                     }
 
                 };


### PR DESCRIPTION
The websocket can get locked up when too many calls to it's `send` method are executed from a different thread than the thread it was created on.

If there seems to be performance issues related to this being on the main thread further work could move all AsyncHttpClient access to a handler thread.
