### PR TITLE
Maven Central/Sonatype configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ android:
 
 before_script:
   # compile the code so gradle and dependencies are all downloaded
-  - ./gradlew assemble
+  - ./gradlew assembleClientDebug
   # Create and start emulator
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
   - emulator -avd test -no-skin -no-audio -no-window &

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -108,13 +108,16 @@ afterEvaluate {
             mavenDeployer {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                  authentication(userName: ossrhUsername, password: ossrhPassword)
+                if (project.hasProperty("ossrhUsername") && project.hasProperty("ossrhPassword")) {
+                    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                      authentication(userName: ossrhUsername, password: ossrhPassword)
+                    }
+
+                    snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                      authentication(userName: ossrhUsername, password: ossrhPassword)
+                    }
                 }
 
-                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                  authentication(userName: ossrhUsername, password: ossrhPassword)
-                }
 
                 pom.project {
                     name "Simperium Android Library"

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -117,10 +117,14 @@ afterEvaluate {
                 }
 
                 pom.project {
+                    name "Simperium Android Library"
+
                     groupId 'com.simperium.android'
                     artifactId 'simperium'
-                    packaging 'jar'
-                    description 'A Gradle plugin for configuring WordPress Android library dependency development setup.'
+
+                    packaging 'aar'
+                    description 'Android Library for building applications using Simperium'
+
                     url 'https://github.com/simperium/simperium-android'
                     scm {
                         connection 'scm:git:https://github.com/simperium/simperium-android.git'

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 
 apply plugin: 'android-library'
 apply plugin: 'maven'
+apply plugin: 'signing'
 
 version gitVersion()
 
@@ -20,7 +21,7 @@ repositories {
 
 android {
   
-    publishNonDefault true
+    defaultPublishConfig 'clientRelease'
 
     dependencies {
         compile 'com.koushikdutta.async:androidasync:1.2.6@jar'
@@ -87,18 +88,64 @@ public final class Version {
     }
 }
 
-if (project.hasProperty("repository")) {
-  afterEvaluate {
-    uploadArchives {
-      repositories {
-        mavenDeployer {
-          repository(url: project.repository)
-          pom.version = project.version
-          pom.artifactId = 'simperium-android'
-        }
-      }
-    }
-  }
-}
-
 tasks.preBuild.dependsOn versionConfig
+
+afterEvaluate {
+
+    configurations {
+        archives {
+            extendsFrom configurations.default
+        }
+    }
+
+    signing {
+        sign configurations.archives
+    }
+
+    uploadArchives {
+        configuration = configurations.archives
+        repositories {
+            mavenDeployer {
+                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                  authentication(userName: ossrhUsername, password: ossrhPassword)
+                }
+
+                snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                  authentication(userName: ossrhUsername, password: ossrhPassword)
+                }
+
+                pom.project {
+                    groupId 'com.simperium.android'
+                    artifactId 'simperium'
+                    packaging 'jar'
+                    description 'A Gradle plugin for configuring WordPress Android library dependency development setup.'
+                    url 'https://github.com/simperium/simperium-android'
+                    scm {
+                        connection 'scm:git:https://github.com/simperium/simperium-android.git'
+                        developerConnection 'scm:git:https://github.com/simperium/simperium-android.git'
+                        url 'https://github.com/simperium/simperium-android.git'
+                    }
+
+                    licenses {
+                        license {
+                            name 'The MIT License (MIT)'
+                            url 'http://opensource.org/licenses/MIT'
+                        }
+                    }
+
+                    developers {
+
+                        developer {
+                            id 'beaucollins'
+                            name 'Robert Collins'
+                            email 'robert@automattic.com'
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding configuration for uploading to Sonatype for syncing artifacts to Maven Central.

For the `uploadArchives` task to work you need to:

1) Have an account with access to the `com.simperium` group on https://issues.sonatype.org/secure/Dashboard.jspa
2) Configure the username and password for that account in `gradle.properties`
3) Setup a GPG key and configure the correct `gradle.properties`

```
signing.keyId=PRIVATE_KEY
signing.password=PRIVATE_KEY_PASSWORD
signing.secretKeyRingFile=PATH_TO_GPG_KEYRING

ossrhUsername=SONATYPE_USERNAME
ossrhPassword=SONATYPE_PASSWORD
```
