### PR TITLE
Changed AndroidAsync version to be a wildcard on version 1.x

### DIFF
--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -24,7 +24,7 @@ android {
     defaultPublishConfig 'clientRelease'
 
     dependencies {
-        compile 'com.koushikdutta.async:androidasync:1.2.6@jar'
+        compile 'com.koushikdutta.async:androidasync:1.+@jar'
         compile 'org.thoughtcrime.ssl.pinning:AndroidPinning:1.0.0'
     }
 


### PR DESCRIPTION
So we are always using the latest releases.

Fixes #140.
