### PR TITLE
Catch IllegalStateException when scheduling timer.

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
+++ b/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
@@ -314,11 +314,17 @@ public class WebSocketManager implements ChannelProvider, Channel.OnMessageListe
         mReconnectTimer = new Timer();
         // exponential backoff
         long retryIn = nextReconnectInterval();
-        mReconnectTimer.schedule(new TimerTask() {
-            public void run() {
-                connect();
-            }
-        }, retryIn);
+        try {
+            mReconnectTimer.schedule(new TimerTask() {
+                public void run() {
+                    connect();
+                }
+            }, retryIn);
+        } catch (IllegalStateException e) {
+            Logger.log(TAG, "Unable to schedule timer", e);
+            return;
+        }
+
         Logger.log(String.format(Locale.US, "Retrying in %d", retryIn));
     }
 


### PR DESCRIPTION
This appears to be a race condition that I couldn't reproduce. The Timer class doesn't have a way to check if it is canceled or not, so I resorted to catching the exception.

Fixes #157 
