### PR TITLE
Also catch an NPE when rescheduling the timer.

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
+++ b/Simperium/src/main/java/com/simperium/android/WebSocketManager.java
@@ -320,7 +320,7 @@ public class WebSocketManager implements ChannelProvider, Channel.OnMessageListe
                     connect();
                 }
             }, retryIn);
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException | NullPointerException e) {
             Logger.log(TAG, "Unable to schedule timer", e);
             return;
         }


### PR DESCRIPTION
cancelReconnect() could have nulled out the timer in between when the timer was created and when the reschedule call happens. In this case the connection has happened anyways so we can just bail out.

Fixes #173
