### PR TITLE
Fix concurrency exceptions when saving object

### DIFF
--- a/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
@@ -39,8 +39,8 @@ public class ChangeTest extends TestCase {
 
         JSONObject diff = change.toJSONObject(object, ghost).getJSONObject("v");
 
-        String expected = "{\"tags\":{\"o\":\"+\",\"v\":[]},\"deleted\":{\"o\":\"+\",\"v\":false},\"title\":{\"o\":\"+\",\"v\":\"Hello world\"}}";
-        assertEquals(expected, diff.toString());
+        JSONObject expected = new JSONObject("{\"tags\":{\"o\":\"+\",\"v\":[]},\"deleted\":{\"o\":\"+\",\"v\":false},\"title\":{\"o\":\"+\",\"v\":\"Hello world\"}}");
+        assertEquals(expected.toString(), diff.toString());
 
     }
 

--- a/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChangeTest.java
@@ -29,8 +29,7 @@ public class ChangeTest extends TestCase {
 
     public void testModifyPayload()
     throws Exception {
-
-        Change change = new Change(Change.OPERATION_MODIFY, mNote);
+        Change change = new Change(Change.OPERATION_MODIFY, mBucket.getName(), mNote.getSimperiumKey());
 
         Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());
         JSONObject object = mNote.getDiffableValue();
@@ -50,7 +49,7 @@ public class ChangeTest extends TestCase {
 
         mNote.save();
 
-        Change change = new Change(Change.OPERATION_REMOVE, mNote);
+        Change change = new Change(Change.OPERATION_REMOVE, mBucket.getName(), mNote.getSimperiumKey());
         Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());
         assertTrue(change.isRemoveOperation());
         assertValidChangeObject(mNote, ghost, change);
@@ -60,7 +59,7 @@ public class ChangeTest extends TestCase {
     public void testChangeWithFullObjectDataPaylaod()
     throws Exception {
 
-        Change change = new Change(Change.OPERATION_MODIFY, mNote);
+        Change change = new Change(Change.OPERATION_MODIFY, mBucket.getName(), mNote.getSimperiumKey());
         change.setSendFullObject(true);
 
         Ghost ghost = mBucket.getGhost(mNote.getSimperiumKey());

--- a/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
@@ -380,17 +380,18 @@ public class ChannelTest extends BaseSimperiumTest {
      * When started without an index a Channel should send a valid init message with the an initial
      * `i` message.
      */
-    public void testInitMessageWithNoChangeVersion(){
-        // 
-        String initMessage = String.format(Locale.US,
-            "init:{\"library\":\"%s\",\"cmd\":\"i::::50\",\"token\":\"%s\",\"version\":%d,\"api\":\"1.1\",\"name\":\"%s\",\"app_id\":\"%s\",\"clientid\":\"%s\"}",
-            "android", mBucket.getUser().getAccessToken(), 0, mBucket.getRemoteName(), APP_ID, SESSION_ID
-        );
+    public void testInitMessageWithNoChangeVersion() throws Exception {
+
+        String json = String.format(Locale.US,
+            "{\"library\":\"%s\",\"cmd\":\"i::::50\",\"token\":\"%s\",\"version\":%d,\"api\":\"1.1\",\"name\":\"%s\",\"app_id\":\"%s\",\"clientid\":\"%s\"}",
+            "android", mBucket.getUser().getAccessToken(), 0, mBucket.getRemoteName(), APP_ID, SESSION_ID);
+
+        JSONObject initMessage = new JSONObject(json);
 
         start();
 
         assertNotNull(mListener.lastMessage);
-        assertEquals(initMessage, mListener.lastMessage.toString());
+        assertEquals("init:" + initMessage.toString(), mListener.lastMessage.toString());
         assertEquals("1.1", mListener.api);
     }
 
@@ -398,19 +399,20 @@ public class ChannelTest extends BaseSimperiumTest {
      * When started with an existing index a Channel should send a valid init message with an
      * initial <code>cv</code> command.
      */
-    public void testInitMessageWithChangeVersion(){
+    public void testInitMessageWithChangeVersion() throws Exception {
         // set a fake change version on the bucket
         String cv = "fake-cv";
 
-        String initMessage = String.format(Locale.US,
-            "init:{\"library\":\"%s\",\"cmd\":\"cv:%s\",\"token\":\"%s\",\"version\":%d,\"api\":\"1.1\",\"name\":\"%s\",\"app_id\":\"%s\",\"clientid\":\"%s\"}",
-            "android", cv, mBucket.getUser().getAccessToken(), 0, mBucket.getRemoteName(), APP_ID, SESSION_ID
-        );
+        String json = String.format(Locale.US,
+                        "{\"library\":\"%s\",\"cmd\":\"cv:%s\",\"token\":\"%s\",\"version\":%d,\"api\":\"1.1\",\"name\":\"%s\",\"app_id\":\"%s\",\"clientid\":\"%s\"}",
+                        "android", cv, mBucket.getUser().getAccessToken(), 0, mBucket.getRemoteName(), APP_ID, SESSION_ID);
+
+        JSONObject initMessage = new JSONObject(json);
         mBucket.setChangeVersion(cv);
 
         start();
 
-        assertEquals(initMessage, mListener.lastMessage.toString());
+        assertEquals("init:" + initMessage.toString(), mListener.lastMessage.toString());
 
     }
 

--- a/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
@@ -702,7 +702,7 @@ public class ChannelTest extends BaseSimperiumTest {
         Note note = mBucket.newObject();
         note.setTitle("My plane is full of snakes");
 
-        Change change = new Change(Change.OPERATION_MODIFY, note);
+        Change change = new Change(Change.OPERATION_MODIFY, mBucket.getName(), note.getSimperiumKey());
 
         // Spam a lot of attempts to requeue a change
         for (int i=0; i < 10; i++) {
@@ -756,7 +756,7 @@ public class ChannelTest extends BaseSimperiumTest {
         note.save();
 
         // queue the note, the change will be empty since it hasn't bee modified
-        mChannel.queueLocalChange(note);
+        mChannel.queueLocalChange(note.getSimperiumKey());
 
         waitFor(200);
 

--- a/Simperium/src/androidTestSupport/java/com/simperium/QueueSerializerTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/QueueSerializerTest.java
@@ -38,7 +38,7 @@ public class QueueSerializerTest extends ActivityInstrumentationTestCase2<LoginA
         BucketObject object = mBucket.newObject();
         object.setProperty("title", "Hola Mundo");
 
-        Change change = new Change(Change.OPERATION_MODIFY, object);
+        Change change = new Change(Change.OPERATION_MODIFY, mBucket.getName(), object.getSimperiumKey());
 
         mSerializer.onQueueChange(change);
 
@@ -55,7 +55,7 @@ public class QueueSerializerTest extends ActivityInstrumentationTestCase2<LoginA
         BucketObject object = mBucket.newObject();
         object.setProperty("title", "Hola Mundo");
 
-        Change change = new Change(Change.OPERATION_REMOVE, object);
+        Change change = new Change(Change.OPERATION_REMOVE, mBucket.getName(), object.getSimperiumKey());
         mSerializer.onQueueChange(change);
 
         SerializedQueue queue = mSerializer.restore(mBucket);

--- a/Simperium/src/androidTestSupport/java/com/simperium/SimperiumTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/SimperiumTest.java
@@ -201,9 +201,9 @@ public class SimperiumTest extends BaseSimperiumTest {
         }
 
         @Override
-        public void save(BucketObject object, List<Index> indexes){
+        public void save(BucketObject object, String simperiumKey, String json, List<Index> indexes) {
             save = true;
-            super.save(object, indexes);
+            super.save(object, simperiumKey, json, indexes);
         }
 
         @Override

--- a/Simperium/src/main/java/com/simperium/android/PersistentStore.java
+++ b/Simperium/src/main/java/com/simperium/android/PersistentStore.java
@@ -96,7 +96,7 @@ public class PersistentStore implements StorageProvider {
 
             cursor.close();
             index(object, indexes);
-            if (BuildConfig.DEBUG) Log.d(TAG, "Saved indexes for " + json);
+            if (BuildConfig.DEBUG) Log.d(TAG, "Saved indexes for " + object);
         }
 
         /**

--- a/Simperium/src/main/java/com/simperium/android/PersistentStore.java
+++ b/Simperium/src/main/java/com/simperium/android/PersistentStore.java
@@ -81,7 +81,7 @@ public class PersistentStore implements StorageProvider {
          * Add/Update the given object
          */
         @Override
-        public void save(String simperiumKey, String json, List<Index> indexes) {
+        public void save(T object, String simperiumKey, String json, List<Index> indexes) {
             mReindexer.skip(simperiumKey);
             ContentValues values = new ContentValues();
             values.put("bucket", mBucketName);
@@ -95,13 +95,8 @@ public class PersistentStore implements StorageProvider {
             }
 
             cursor.close();
-            // TODO FIXME: index(object, indexes);
+            index(object, indexes);
             if (BuildConfig.DEBUG) Log.d(TAG, "Saved indexes for " + json);
-        }
-
-        @Override
-        public void save(T object, List<Index> indexes) {
-            //noop
         }
 
         /**

--- a/Simperium/src/main/java/com/simperium/android/PersistentStore.java
+++ b/Simperium/src/main/java/com/simperium/android/PersistentStore.java
@@ -81,27 +81,27 @@ public class PersistentStore implements StorageProvider {
          * Add/Update the given object
          */
         @Override
-        public void save(T object, List<Index> indexes) {
-
-            JSONObject data = object.getDiffableValue();
-            String raw = data.toString();
-
-            String key = object.getSimperiumKey();
-            mReindexer.skip(key);
+        public void save(String simperiumKey, String json, List<Index> indexes) {
+            mReindexer.skip(simperiumKey);
             ContentValues values = new ContentValues();
             values.put("bucket", mBucketName);
-            values.put("key", key);
-            values.put("data", raw);
-            Cursor cursor = queryObject(mBucketName, key);
+            values.put("key", simperiumKey);
+            values.put("data", json);
+            Cursor cursor = queryObject(mBucketName, simperiumKey);
             if (cursor.getCount() == 0) {
                 mDatabase.insert(OBJECTS_TABLE, null, values);
             } else {
-                mDatabase.update(OBJECTS_TABLE, values, "bucket=? AND key=?", new String[]{mBucketName, key});
+                mDatabase.update(OBJECTS_TABLE, values, "bucket=? AND key=?", new String[]{mBucketName, simperiumKey});
             }
 
             cursor.close();
-            index(object, indexes);
-            if (BuildConfig.DEBUG) Log.d(TAG, "Saved indexes for " + object);
+            // TODO FIXME: index(object, indexes);
+            if (BuildConfig.DEBUG) Log.d(TAG, "Saved indexes for " + json);
+        }
+
+        @Override
+        public void save(T object, List<Index> indexes) {
+            //noop
         }
 
         /**

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -292,11 +292,7 @@ public class Bucket<T extends Syncable> {
             @Override
             public void run() {
                 try {
-                    if (mStorage instanceof MemoryStore) {
-                        mStorage.save(object, mSchema.indexesFor(object));
-                    } else {
-                        mStorage.save(simperiumKey, objectJSON, mSchema.indexesFor(object));
-                    }
+                    mStorage.save(object, simperiumKey, objectJSON, mSchema.indexesFor(object));
 
                     // Save a copy in case the object is removed from storage before this modification has been processed
                     storeBackupCopy(object);
@@ -711,7 +707,7 @@ public class Bucket<T extends Syncable> {
         }
         object.setBucket(this);
         JSONObject objectJSON = object.getDiffableValue();
-        mStorage.save(object.getSimperiumKey(), objectJSON.toString(), mSchema.indexesFor(object));
+        mStorage.save(object, object.getSimperiumKey(), objectJSON.toString(), mSchema.indexesFor(object));
         // notify listeners that an object has been added
     }
 
@@ -722,7 +718,7 @@ public class Bucket<T extends Syncable> {
         object.setBucket(this);
 
         String json = object.getDiffableValue().toString();
-        mStorage.save(object.getSimperiumKey(), json, mSchema.indexesFor(object));
+        mStorage.save(object, object.getSimperiumKey(), json, mSchema.indexesFor(object));
     }
 
     /**

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -282,8 +282,6 @@ public class Bucket<T extends Syncable> {
      */
     public void sync(final T object) {
         final String simperiumKey = object.getSimperiumKey();
-
-        // TODO Analyze performance
         final String objectJSON = object.getDiffableValue().toString();
         final Boolean modified = object.isModified();
 
@@ -314,7 +312,7 @@ public class Bucket<T extends Syncable> {
     /**
      * Delete the object from the bucket.
      *
-     * @param object the object to remove from the bucket
+     * @param object the Syncable to remove from the bucket
      */
     public void remove(T object) {
         remove(object, true);
@@ -493,7 +491,7 @@ public class Bucket<T extends Syncable> {
         if (object == null) {
             throw(new BucketObjectMissingException(String.format("Storage provider for bucket:%s did not have object %s", getName(), key)));
         }
-        Logger.log(TAG, String.format("Fetched ghostly for %s %s", key, ghost));
+        Logger.log(TAG, String.format("Fetched ghost for %s %s", key, ghost));
         object.setBucket(this);
         object.setGhost(ghost);
         updateBackupStoreGhost(ghost);

--- a/Simperium/src/main/java/com/simperium/client/Change.java
+++ b/Simperium/src/main/java/com/simperium/client/Change.java
@@ -65,11 +65,7 @@ public class Change {
         return new Change(operation, ccid, bucketName, key);
     }
 
-    public Change(String operation, Syncable object){
-        this(operation, object.getBucketName(), object.getSimperiumKey());
-    }
-
-    protected Change(String operation, String bucketName, String key){
+    public Change(String operation, String bucketName, String key){
         this(operation, uuid(), bucketName, key);
     }
 

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -333,14 +333,14 @@ public class Channel implements Bucket.Channel {
     /**
      * Diffs and object's local modifications and queues up the changes
      */
-    public Change queueLocalChange(Syncable object) {
-        Change change = new Change(Change.OPERATION_MODIFY, object);
+    public Change queueLocalChange(String simperiumKey) {
+        Change change = new Change(Change.OPERATION_MODIFY, this.getBucketName(), simperiumKey);
         mChangeProcessor.addChange(change);
         return change;
     }
 
     public Change queueLocalDeletion(Syncable object) {
-        Change change = new Change(Change.OPERATION_REMOVE, object);
+        Change change = new Change(Change.OPERATION_REMOVE, this.getBucketName(), object.getSimperiumKey());
         mChangeProcessor.addChange(change);
         return change;
     }

--- a/Simperium/src/main/java/com/simperium/storage/MemoryStore.java
+++ b/Simperium/src/main/java/com/simperium/storage/MemoryStore.java
@@ -6,6 +6,8 @@ import com.simperium.client.BucketSchema.Index;
 import com.simperium.client.Query;
 import com.simperium.client.Syncable;
 
+import org.json.JSONObject;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -25,6 +27,11 @@ public class MemoryStore implements StorageProvider {
 
         @Override
         public void prepare(Bucket<T> bucket){
+            // noop
+        }
+
+        @Override
+        public void save(String simperiumKey, String json, List<Index> indexes) {
             // noop
         }
 

--- a/Simperium/src/main/java/com/simperium/storage/MemoryStore.java
+++ b/Simperium/src/main/java/com/simperium/storage/MemoryStore.java
@@ -30,17 +30,12 @@ public class MemoryStore implements StorageProvider {
             // noop
         }
 
-        @Override
-        public void save(String simperiumKey, String json, List<Index> indexes) {
-            // noop
-        }
-
         /**
          * Add/Update the given object
          */
         @Override
-        public void save(T object, List<Index> indexes){
-            objects.put(object.getSimperiumKey(), object);
+        public void save(T object, String simperiumKey, String json, List<Index> indexes) {
+            objects.put(simperiumKey, object);
         }
 
         /**

--- a/Simperium/src/main/java/com/simperium/storage/StorageProvider.java
+++ b/Simperium/src/main/java/com/simperium/storage/StorageProvider.java
@@ -7,6 +7,8 @@ import com.simperium.client.BucketSchema.Index;
 import com.simperium.client.Query;
 import com.simperium.client.Syncable;
 
+import org.json.JSONObject;
+
 import java.util.List;
 
 public interface StorageProvider {
@@ -24,6 +26,8 @@ public interface StorageProvider {
         /**
          * Add/Update the given object
          */
+        public void save(String simperiumKey, String json, List<Index> indexes);
+
         public void save(T object, List<Index> indexes);
 
         /**

--- a/Simperium/src/main/java/com/simperium/storage/StorageProvider.java
+++ b/Simperium/src/main/java/com/simperium/storage/StorageProvider.java
@@ -26,9 +26,7 @@ public interface StorageProvider {
         /**
          * Add/Update the given object
          */
-        public void save(String simperiumKey, String json, List<Index> indexes);
-
-        public void save(T object, List<Index> indexes);
+        public void save(T object, String simperiumKey, String json, List<Index> indexes);
 
         /**
          * Remove the given object from the storage

--- a/Simperium/src/support/java/com/simperium/test/MockBucketStore.java
+++ b/Simperium/src/support/java/com/simperium/test/MockBucketStore.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONObject;
+
 public class MockBucketStore<T extends Syncable> implements StorageProvider.BucketStore<T> {
 
     static public final String TAG = "Simperium.MockBucketStore";
@@ -32,6 +34,11 @@ public class MockBucketStore<T extends Syncable> implements StorageProvider.Buck
     @Override
     public void save(T object, List<Index> indexes){
         objects.put(object.getSimperiumKey(), object);
+    }
+
+    @Override
+    public void save(String simperiumKey, JSONObject data, List<Index> indexes) {
+        //noop
     }
 
     /**

--- a/Simperium/src/support/java/com/simperium/test/MockBucketStore.java
+++ b/Simperium/src/support/java/com/simperium/test/MockBucketStore.java
@@ -32,13 +32,8 @@ public class MockBucketStore<T extends Syncable> implements StorageProvider.Buck
      * Add/Update the given object
      */
     @Override
-    public void save(T object, List<Index> indexes){
-        objects.put(object.getSimperiumKey(), object);
-    }
-
-    @Override
-    public void save(String simperiumKey, JSONObject data, List<Index> indexes) {
-        //noop
+    public void save(T object, String simperiumKey, String json, List<Index> indexes) {
+        objects.put(simperiumKey, object);
     }
 
     /**

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -33,7 +33,7 @@ public class MockChannel implements Bucket.Channel {
 
     @Override
     public Change queueLocalDeletion(Syncable object){
-        Change change = new Change(Change.OPERATION_REMOVE, object);
+        Change change = new Change(Change.OPERATION_REMOVE, mBucket.getName(), object.getSimperiumKey());
         try {
             if(started && autoAcknowledge) acknowledge(change);
         } catch (Exception e) {
@@ -48,8 +48,8 @@ public class MockChannel implements Bucket.Channel {
     }
 
     @Override
-    public Change queueLocalChange(Syncable object) {
-        Change change = new Change(Change.OPERATION_MODIFY, object);
+    public Change queueLocalChange(String simperiumKey) {
+        Change change = new Change(Change.OPERATION_MODIFY, mBucket.getName(), simperiumKey);
         try {
             if(started && autoAcknowledge) acknowledge(change);
         } catch (Exception e) {


### PR DESCRIPTION
Passes the JSON string and Simperium key to the save operation instead of the Simperium object. This should prevent the concurrency exception that we've seen in the WordPress app.

@beaucollins Hoping you can take a peek at this! 

Note: I still passed the object through so that the indexer would still work properly. I don't think it modifies the object so it looked ok to leave it as-is.
