### PR TITLE
Adds Support for Retrieving Object Revisions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 jdk: oraclejdk7
+sudo: false
 env:
   matrix:
     - ANDROID_TARGET=android-21  ANDROID_ABI=armeabi-v7a

--- a/Simperium/src/main/java/com/simperium/android/GhostStore.java
+++ b/Simperium/src/main/java/com/simperium/android/GhostStore.java
@@ -152,7 +152,6 @@ public class GhostStore implements GhostStorageProvider {
         return version;
     }
 
-
     @Override
     public boolean hasGhost(Bucket bucket, String key) {
         try {

--- a/Simperium/src/main/java/com/simperium/android/GhostStore.java
+++ b/Simperium/src/main/java/com/simperium/android/GhostStore.java
@@ -137,6 +137,23 @@ public class GhostStore implements GhostStorageProvider {
     }
 
     @Override
+    public int getGhostVersion(Bucket bucket, String key) throws GhostMissingException {
+        String[] columns = { VERSION_FIELD };
+        String where = "bucketName=? AND simperiumKey=?";
+        String[] args = { bucket.getName(), key };
+
+        Cursor cursor = database.query(GHOSTS_TABLE_NAME, columns, where, args, null, null, "version DESC", "1");
+        int version = -1;
+        if(cursor.moveToFirst()){
+            version = cursor.getInt(0);
+        }
+        cursor.close();
+        if (version == -1) throw(new GhostMissingException(String.format("Ghost %s does not exist for bucket %s", bucket.getName(), key)));
+        return version;
+    }
+
+
+    @Override
     public boolean hasGhost(Bucket bucket, String key) {
         try {
             getGhost(bucket, key);

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -1021,42 +1021,58 @@ public class Bucket<T extends Syncable> {
         }
     }
 
-    public void getRevisions(T object, int max, RevisionsRequestCallbacks<T> callbacks) {
-        getRevisions(object.getSimperiumKey(), object.getVersion(), max, callbacks);
+    public void getRevisions(final T object, final int max, final RevisionsRequestCallbacks<T> callbacks) {
+        mExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                getRevisions(object.getSimperiumKey(), object.getVersion(), max, callbacks);
+            }
+        });
     }
 
-    public void getRevisions(T object, RevisionsRequestCallbacks<T> callbacks) {
-        getRevisions(object.getSimperiumKey(), object.getVersion(), 0, callbacks);
+    public void getRevisions(final T object, final RevisionsRequestCallbacks<T> callbacks) {
+        mExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                getRevisions(object.getSimperiumKey(), object.getVersion(), 0, callbacks);
+            }
+        });
     }
 
     /**
      * Request revision history for object with the given key
      */
-    public void getRevisions(String key, RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
-        int version;
-        try {
-            version = mGhostStore.getGhostVersion(this, key);
-        } catch (GhostMissingException e) {
-            callbacks.onError(e);
-            throw e;
-        }
-
-        getRevisions(key, version, 0, callbacks);
+    public void getRevisions(final String key, final RevisionsRequestCallbacks<T> callbacks) {
+        mExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                int version;
+                try {
+                    version = mGhostStore.getGhostVersion(Bucket.this, key);
+                    getRevisions(key, version, 0, callbacks);
+                } catch (GhostMissingException e) {
+                    callbacks.onError(e);
+                }
+            }
+        });
     }
 
-    public void getRevisions(String key, int max, RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
-        int version;
-        try {
-            version = mGhostStore.getGhostVersion(this, key);
-        } catch (GhostMissingException e) {
-            callbacks.onError(e);
-            throw e;
-        }
-
-        getRevisions(key, version, max, callbacks);
+    public void getRevisions(final String key, final int max, final RevisionsRequestCallbacks<T> callbacks) {
+        mExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                int version;
+                try {
+                    version = mGhostStore.getGhostVersion(Bucket.this, key);
+                    getRevisions(key, version, max, callbacks);
+                } catch (GhostMissingException e) {
+                    callbacks.onError(e);
+                }
+            }
+        });
     }
 
-    public void getRevisions(String key, int version, int max, final RevisionsRequestCallbacks<T> callbacks){
+    private void getRevisions(String key, int version, int max, final RevisionsRequestCallbacks<T> callbacks){
         mChannel.getRevisions(key, version, max, new RevisionsRequestCallbacks() {
 
             @Override

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -1021,6 +1021,29 @@ public class Bucket<T extends Syncable> {
         }
     }
 
+    /**
+     * Request revision history for an object. Called by all of the public getRevision() methods.
+     */
+    private void getRevisions(String key, int version, int max, final RevisionsRequestCallbacks<T> callbacks) {
+        mChannel.getRevisions(key, version, max, new RevisionsRequestCallbacks() {
+
+            @Override
+            public void onComplete(Map revisions) {
+                callbacks.onComplete(revisions);
+            }
+
+            @Override
+            public void onRevision(String key, int version, JSONObject object) {
+                callbacks.onRevision(key, version, object);
+            }
+
+            @Override
+            public void onError(Throwable exception) {
+                callbacks.onError(exception);
+            }
+        });
+    }
+
     public void getRevisions(final T object, final int max, final RevisionsRequestCallbacks<T> callbacks) {
         mExecutor.execute(new Runnable() {
             @Override
@@ -1039,9 +1062,6 @@ public class Bucket<T extends Syncable> {
         });
     }
 
-    /**
-     * Request revision history for object with the given key
-     */
     public void getRevisions(final String key, final RevisionsRequestCallbacks<T> callbacks) {
         mExecutor.execute(new Runnable() {
             @Override
@@ -1068,26 +1088,6 @@ public class Bucket<T extends Syncable> {
                 } catch (GhostMissingException e) {
                     callbacks.onError(e);
                 }
-            }
-        });
-    }
-
-    private void getRevisions(String key, int version, int max, final RevisionsRequestCallbacks<T> callbacks){
-        mChannel.getRevisions(key, version, max, new RevisionsRequestCallbacks() {
-
-            @Override
-            public void onComplete(Map revisions) {
-                callbacks.onComplete(revisions);
-            }
-
-            @Override
-            public void onRevision(String key, int version, JSONObject object) {
-                callbacks.onRevision(key, version, object);
-            }
-
-            @Override
-            public void onError(Throwable exception) {
-                callbacks.onError(exception);
             }
         });
     }

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -75,7 +75,7 @@ public class Bucket<T extends Syncable> {
     }
 
     public interface RevisionsRequestCallbacks<T extends Syncable> {
-        void onComplete();
+        void onComplete(Map<Integer, T> revisions);
         void onRevision(String key, int version, JSONObject object);
         void onError(Throwable exception);
     }
@@ -83,7 +83,6 @@ public class Bucket<T extends Syncable> {
     public interface RevisionsRequest {
         boolean isComplete();
     }
-
 
     /**
      * A one-way exclusion lock that stores multiple keys in a Set. Designed for use with two types of threads,
@@ -599,7 +598,6 @@ public class Bucket<T extends Syncable> {
         });
     }
 
-
     /**
      * Update the ghost data
      */
@@ -1045,13 +1043,12 @@ public class Bucket<T extends Syncable> {
         return mChannel.getRevisions(key, version, new RevisionsRequestCallbacks() {
 
             @Override
-            public void onComplete() {
-                callbacks.onComplete();
+            public void onComplete(Map revisions) {
+                callbacks.onComplete(revisions);
             }
 
             @Override
             public void onRevision(String key, int version, JSONObject object) {
-                // build the object, set the read only ghost and call the callback
                 callbacks.onRevision(key, version, object);
             }
 
@@ -1062,6 +1059,4 @@ public class Bucket<T extends Syncable> {
 
         });
     }
-
-
 }

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -49,7 +49,7 @@ public class Bucket<T extends Syncable> {
         void stop();
         void reset();
         boolean isIdle();
-        RevisionsRequest getRevisions(String key, int sinceVersion, int maxVersion, RevisionsRequestCallbacks callbacks);
+        void getRevisions(String key, int sinceVersion, int maxVersion, RevisionsRequestCallbacks callbacks);
     }
 
     public interface OnBeforeUpdateObjectListener<T extends Syncable> {
@@ -1021,18 +1021,18 @@ public class Bucket<T extends Syncable> {
         }
     }
 
-    public RevisionsRequest getRevisions(T object, int max, RevisionsRequestCallbacks<T> callbacks) {
-        return getRevisions(object.getSimperiumKey(), object.getVersion(), max, callbacks);
+    public void getRevisions(T object, int max, RevisionsRequestCallbacks<T> callbacks) {
+        getRevisions(object.getSimperiumKey(), object.getVersion(), max, callbacks);
     }
 
-    public RevisionsRequest getRevisions(T object, RevisionsRequestCallbacks<T> callbacks) {
-        return getRevisions(object.getSimperiumKey(), object.getVersion(), 0, callbacks);
+    public void getRevisions(T object, RevisionsRequestCallbacks<T> callbacks) {
+        getRevisions(object.getSimperiumKey(), object.getVersion(), 0, callbacks);
     }
 
     /**
      * Request revision history for object with the given key
      */
-    public RevisionsRequest getRevisions(String key, RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
+    public void getRevisions(String key, RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
         int version;
         try {
             version = mGhostStore.getGhostVersion(this, key);
@@ -1040,10 +1040,11 @@ public class Bucket<T extends Syncable> {
             callbacks.onError(e);
             throw e;
         }
-        return getRevisions(key, version, 0, callbacks);
+
+        getRevisions(key, version, 0, callbacks);
     }
 
-    public RevisionsRequest getRevisions(String key, int max, RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
+    public void getRevisions(String key, int max, RevisionsRequestCallbacks<T> callbacks) throws GhostMissingException {
         int version;
         try {
             version = mGhostStore.getGhostVersion(this, key);
@@ -1051,11 +1052,12 @@ public class Bucket<T extends Syncable> {
             callbacks.onError(e);
             throw e;
         }
-        return getRevisions(key, version, max, callbacks);
+
+        getRevisions(key, version, max, callbacks);
     }
 
-    public RevisionsRequest getRevisions(String key, int version, int max, final RevisionsRequestCallbacks<T> callbacks){
-        return mChannel.getRevisions(key, version, max, new RevisionsRequestCallbacks() {
+    public void getRevisions(String key, int version, int max, final RevisionsRequestCallbacks<T> callbacks){
+        mChannel.getRevisions(key, version, max, new RevisionsRequestCallbacks() {
 
             @Override
             public void onComplete(Map revisions) {
@@ -1071,7 +1073,6 @@ public class Bucket<T extends Syncable> {
             public void onError(Throwable exception) {
                 callbacks.onError(exception);
             }
-
         });
     }
 }

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -49,7 +49,7 @@ public class Bucket<T extends Syncable> {
         void stop();
         void reset();
         boolean isIdle();
-        void getRevisions(String key, int sinceVersion, int maxVersion, RevisionsRequestCallbacks callbacks);
+        void getRevisions(String key, int sinceVersion, int maxVersionCount, RevisionsRequestCallbacks callbacks);
     }
 
     public interface OnBeforeUpdateObjectListener<T extends Syncable> {

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -383,7 +383,6 @@ public class Channel implements Bucket.Channel {
             // received an index page for a different change version
             // TODO: reconcile the out of band index cv
         }
-
     }
 
     private IndexProcessorListener mIndexProcessorListener = new IndexProcessorListener() {
@@ -445,18 +444,14 @@ public class Channel implements Bucket.Channel {
         } catch (ObjectVersionParseException e) {
             log(LOG_DEBUG, String.format(Locale.US, "Received invalid object version: %s", e.versionString));
         }
-
-
     }
 
     /**
      * Stop sending changes and download a new index
      */
     private void stopChangesAndRequestIndex() {
-
         // get the latest index
         getLatestVersions();
-
     }
 
     /**
@@ -525,7 +520,6 @@ public class Channel implements Bucket.Channel {
 
 
                 sendMessage(String.format("%s:%s", COMMAND_INDEX_STATE, index));
-
             }
 
         });
@@ -566,13 +560,11 @@ public class Channel implements Bucket.Channel {
     }
 
     @Override
-    public Bucket.RevisionsRequest getRevisions(String key, int sinceVersion, int max, Bucket.RevisionsRequestCallbacks callbacks) {
+    public void getRevisions(final String key, final int sinceVersion, final int max, final Bucket.RevisionsRequestCallbacks callbacks) {
         // for the key and version iterate down requesting the each version for the object
         RevisionsCollector collector = new RevisionsCollector(key, sinceVersion, max, callbacks);
         revisionCollectors.add(collector);
         collector.send();
-        // collect the responses back
-        return collector;
     }
 
     public void log(int level, CharSequence message) {

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -560,11 +560,16 @@ public class Channel implements Bucket.Channel {
         return mIdle;
     }
 
+    @Override
+    public Bucket.RevisionsRequest getRevisions(String key, int sinceVersion, Bucket.RevisionsRequestCallbacks callbacks) {
+        // todo get the revisions :)
+        return null;
+    }
+
     public void log(int level, CharSequence message) {
         if (this.mListener != null) {
             this.mListener.onLog(this, level, message);
         }
-
     }
 
     /**

--- a/Simperium/src/main/java/com/simperium/client/Channel.java
+++ b/Simperium/src/main/java/com/simperium/client/Channel.java
@@ -578,9 +578,10 @@ public class Channel implements Bucket.Channel {
     }
 
     @Override
-    public void getRevisions(final String key, final int sinceVersion, final int max, final Bucket.RevisionsRequestCallbacks callbacks) {
+    public void getRevisions(final String key, final int sinceVersion, final int maxVersionCount,
+                             final Bucket.RevisionsRequestCallbacks callbacks) {
         // for the key and version iterate down requesting the each version for the object
-        RevisionsCollector collector = new RevisionsCollector(key, sinceVersion, max, callbacks);
+        RevisionsCollector collector = new RevisionsCollector(key, sinceVersion, maxVersionCount, callbacks);
         revisionCollectors.add(collector);
         collector.send();
     }
@@ -929,7 +930,7 @@ public class Channel implements Bucket.Channel {
 
         final private String key;
         final private int sinceVersion;
-        final private int maxRevisions;
+        final private int maxVersionCount;
         final private Bucket.RevisionsRequestCallbacks callbacks;
         private boolean completed = true;
         private boolean sent = false;
@@ -937,10 +938,10 @@ public class Channel implements Bucket.Channel {
 
         private Map<Integer, Syncable> versionsMap = Collections.synchronizedSortedMap(new TreeMap<Integer, Syncable>());
 
-        RevisionsCollector(String key, int sinceVersion, int maxRevisions, Bucket.RevisionsRequestCallbacks callbacks) {
+        RevisionsCollector(String key, int sinceVersion, int maxVersions, Bucket.RevisionsRequestCallbacks callbacks) {
             this.key = key;
             this.sinceVersion = sinceVersion;
-            this.maxRevisions = Math.max(maxRevisions, 1);
+            this.maxVersionCount = Math.max(maxVersions, 1);
             this.callbacks = callbacks;
         }
 
@@ -955,7 +956,7 @@ public class Channel implements Bucket.Channel {
 
             if (!sent) {
                 sent = true;
-                int minVersion = (sinceVersion - maxRevisions > 0) ? sinceVersion - maxRevisions : 1;
+                int minVersion = (sinceVersion - maxVersionCount > 0) ? sinceVersion - maxVersionCount : 1;
                 mTotalRevisions = sinceVersion - minVersion;
                 // for each version send an e: request
                 for (int i = minVersion; i < sinceVersion; i++) {

--- a/Simperium/src/main/java/com/simperium/client/GhostStorageProvider.java
+++ b/Simperium/src/main/java/com/simperium/client/GhostStorageProvider.java
@@ -26,6 +26,10 @@ public interface GhostStorageProvider {
      */
     public Ghost getGhost(Bucket bucket, String key) throws GhostMissingException;
     /**
+     * Get a ghost's version number
+     */
+    public int getGhostVersion(Bucket bucket, String key) throws GhostMissingException;
+    /**
      * Saves the provided ghost to the bucket
      */
     public void saveGhost(Bucket bucket, Ghost ghost);

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -10,6 +10,8 @@ import com.simperium.client.RemoteChange;
 import com.simperium.client.RemoteChangeInvalidException;
 import com.simperium.client.Syncable;
 import com.simperium.util.Uuid;
+import com.simperium.client.Bucket.RevisionsRequest;
+import com.simperium.client.Bucket.RevisionsRequestCallbacks;
 
 import android.util.Log;
 
@@ -73,6 +75,11 @@ public class MockChannel implements Bucket.Channel {
 
     @Override
     public void stop(){}
+
+    @Override
+    public RevisionsRequest getRevisions(String key, int version, int max, final RevisionsRequestCallbacks callbacks) {
+        return null;
+    }
 
     /**
      * Simulate an acknowledged change

--- a/Simperium/src/support/java/com/simperium/test/MockChannel.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannel.java
@@ -77,8 +77,8 @@ public class MockChannel implements Bucket.Channel {
     public void stop(){}
 
     @Override
-    public RevisionsRequest getRevisions(String key, int version, int max, final RevisionsRequestCallbacks callbacks) {
-        return null;
+    public void getRevisions(String key, int version, int max, final RevisionsRequestCallbacks callbacks) {
+        throw new RuntimeException("Not implemented");
     }
 
     /**

--- a/Simperium/src/support/java/com/simperium/test/MockGhostStore.java
+++ b/Simperium/src/support/java/com/simperium/test/MockGhostStore.java
@@ -65,6 +65,16 @@ public class MockGhostStore implements GhostStorageProvider {
         return ghost;
     }
 
+    @Override
+    public int getGhostVersion(Bucket bucket, String key) throws GhostMissingException {
+        Map<String,Ghost> ghosts = ghostsForBucket(bucket);
+        Ghost ghost = ghosts.get(key);
+        if (ghost == null) {
+            throw(new GhostMissingException());
+        }
+        return ghost.getVersion();
+    }
+
     /**
      * Saves the provided ghost to the bucket
      */


### PR DESCRIPTION
Clients can call `Bucket.getRevisions()` to request the version history for an object in the bucket. The versioned objects that are returned are currently stored in memory (this is how the other simperium libraries do it and I guess it hasn't been an issue)

For good times, hook this up to Simplenote's 74-note-history branch to try out note restoration!

@beaucollins needs review! I'm wondering if you have some ideas on how to write tests for this. I was thinking of having it test against a real simperium app instead of the mocked stuff.

Fixes #10 
