### PR TITLE
Update Login Form UI

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/LoginActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/LoginActivity.java
@@ -11,6 +11,7 @@ import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.Window;
 import android.view.inputmethod.InputMethodManager;
@@ -149,6 +150,33 @@ public class LoginActivity extends Activity {
                 Uri uriUrl = Uri.parse("https://simperium.com/tos/");
                 Intent launchBrowser = new Intent(Intent.ACTION_VIEW, uriUrl);
                 startActivity(launchBrowser);
+            }
+        });
+
+        passwordTextField.setOnKeyListener(new View.OnKeyListener() {
+            @Override
+            public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
+                if (passwordTextField2.getVisibility() == View.GONE &&
+                        keyEvent.getAction() == KeyEvent.ACTION_DOWN &&
+                        keyCode == KeyEvent.KEYCODE_ENTER) {
+                    signIn();
+                    return true;
+                }
+
+                return false;
+            }
+        });
+
+        passwordTextField2.setOnKeyListener(new View.OnKeyListener() {
+            @Override
+            public boolean onKey(View view, int keyCode, KeyEvent keyEvent) {
+                if (keyEvent.getAction() == KeyEvent.ACTION_DOWN &&
+                        keyCode == KeyEvent.KEYCODE_ENTER) {
+                    signUp();
+                    return true;
+                }
+
+                return false;
             }
         });
 

--- a/Simperium/src/main/res/layout/login.xml
+++ b/Simperium/src/main/res/layout/login.xml
@@ -13,7 +13,7 @@
             android:paddingTop="16dp"
             android:paddingBottom="16dp"
             android:gravity="center"
-            android:layout_gravity="center|top">
+            android:layout_gravity="center">
 
         <ImageView
                 android:id="@+id/logo_login"


### PR DESCRIPTION
Fixed gravity of login form to look better on Chrome OS or devices with a hardware keyboard.

Before:

![screenshot 2018-03-13 at 3 35 51 pm](https://user-images.githubusercontent.com/789137/37376693-ccc03798-26e2-11e8-9c57-4ca262bedeac.png)

After:
![screenshot 2018-03-13 at 3 36 18 pm](https://user-images.githubusercontent.com/789137/37376699-d31121de-26e2-11e8-93d6-bd52a4742644.png)

The soft keyboard will still push up the view to be visible on smaller devices:
![screenshot_1520980685](https://user-images.githubusercontent.com/789137/37376711-e1ac0dee-26e2-11e8-8453-39769d3f5864.png)

Also, the Enter key will now sign in/up when hitting the enter key on the keyboard.