### PR TITLE
Add support for case-insensitive search for UTF strings.

### DIFF
--- a/Simperium/src/androidTestSupport/java/com/simperium/PersistentStoreTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/PersistentStoreTest.java
@@ -362,12 +362,17 @@ public class PersistentStoreTest extends PersistentStoreBaseTest {
         note.setContent("lorem ipsum dolor whatever");
         note.addTags("literature");
 
+        note = mBucket.newObject("ftsearch4");
+        note.setContent("Бабушка means Grandmother.");
+        note.save();
+
         assertEquals(1, mBucket.query().where(new Query.FullTextMatch("town hall")).count());
 
         assertEquals(2, mBucket.query().where(new Query.FullTextMatch("two")).count());
 
         assertEquals(1, mBucket.query().where(new Query.FullTextMatch("tags:two")).count());
 
+        assertEquals(1, mBucket.query().where(new Query.FullTextMatch("бабушка")).count());
     }
 
     public void testFullTextSnippet()

--- a/Simperium/src/main/java/com/simperium/android/PersistentStore.java
+++ b/Simperium/src/main/java/com/simperium/android/PersistentStore.java
@@ -275,6 +275,10 @@ public class PersistentStore implements StorageProvider {
                 if (rebuild) {
                     mDatabase.execSQL(String.format(Locale.US, "DROP TABLE IF EXISTS `%s`", tableName));
                     StringBuilder fields = new StringBuilder();
+                    if (supportsUnicodeFullText()) {
+                        // Add unicode case-insensitive search support
+                        fields.append("tokenize=unicode61, ");
+                    }
                     for (String key : keys) {
                         fields.append("`");
                         fields.append(key);
@@ -630,7 +634,7 @@ public class PersistentStore implements StorageProvider {
     }
 
     // See issue #150, Android < 15 can't use distinct in full text queries
-    public static boolean supportsDistinct(boolean fullTextQuery) {
+    static boolean supportsDistinct(boolean fullTextQuery) {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
             return true;
@@ -638,7 +642,11 @@ public class PersistentStore implements StorageProvider {
 
         // Otherwise only use distinct if it's not a full text query
         return !fullTextQuery;
+    }
 
+    // Android < 21 can't use `unicode61` SQLite tokenizer
+    static boolean supportsUnicodeFullText() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
 
 


### PR DESCRIPTION
https://github.com/Automattic/simplenote-android/issues/278 brought me here :)

We can add a tokenizer that supports case-insensitive search for UTF strings on Android devices running lollipop or higher.

I added a test, run it using `./gradlew cAT`.