### PR TITLE
Syncing Issue

### DIFF
--- a/Simperium/src/androidTestSupport/java/com/simperium/BucketTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/BucketTest.java
@@ -214,7 +214,9 @@ public class BucketTest extends TestCase {
 
         mBucket.updateGhost(ghost, null);
 
-        assertEquals("", note.getContent());
+        // This is an approximation of the expected outcome, not confident yet in what it's
+        // supposed to be
+        assertEquals("Line 1\nLine 2\nLine C\nLine A\nLine B\n", note.getContent());
     }
 
     /**


### PR DESCRIPTION
Failing test to reproduce #201 / Simperium/simplenote-android#560

We can probably make a better test using `JSONDiff.transform` directly now that we're close to the source of the problem.

This is where the simperium client attempts to rebase a change on top of the server's state.

If you think about it in terms of git the client has a local branch that is one commit ahead of what it knows to be the remote branch.

Meanwhile someone else pushed a commit to the remote branch before the client could. When it reconnects to the server it does effectively a `git pull --rebase` so it can apply its local changes on top of the changes made by the other client.

This happens in `JSONDiff.transform`: https://github.com/Simperium/simperium-android/blob/877d4e77ebf84c377134cdc1c6a76f7b87ce4a79/Simperium/src/main/java/com/simperium/util/JSONDiff.java#L37-L68

- **jsondiff**: [Code referenced in comment of `simperium-android`][jsondiff]
- **iOS**/**macOS**: [Performed by `SPMemberText`'s implementation of `[SPMember transform...]`][objc]
- **node-simperium**/**GAE**: [Performed in JSONDiff][js]

[objc]: https://github.com/Simperium/simperium-ios/blob/396c888b2055d5c81d00032a08e50d567d52530b/Simperium/SPMemberText.m#L96
[js]: https://github.com/Simperium/node-simperium/blob/master/src/simperium/jsondiff/jsondiff.js#L359-L366
[jsondiff]: https://github.com/Simperium/jsondiff/blob/eb61ad1e4554450cc14af1938847f18513db946b/src/jsondiff.coffee#L458-L503