### PR TITLE
When a merge fails, queue the object to be synced again

### DIFF
--- a/Simperium/src/androidTestSupport/java/com/simperium/JSONDiffTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/JSONDiffTest.java
@@ -338,6 +338,24 @@ public class JSONDiffTest extends TestCase {
 
     }
 
+    public void testInvalidStringTransformThrowsException()
+            throws Exception {
+        String origin = "Line 1\nLine 2\nReplace me";
+        try
+        {
+            JSONObject transformed = JSONDiff.transform(
+                    "=14\t+Before%0A\t=10\t+%0AAfter",
+                    "=14\t-10\t+BYE",
+                    origin
+            );
+            fail("Patch transform should have failed.");
+        }
+        catch(Exception e)
+        {
+            // Test passed
+        }
+    }
+
     public void testTransformObjectDiffChangeRemovedKey()
     throws Exception {
 

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -648,8 +648,10 @@ public class Bucket<T extends Syncable> {
                             object.setGhost(ghost);
                             updateObject(object);
                         } catch (JSONException | IllegalArgumentException e) {
-                            // Could not apply patch, update from the ghost
-                            updateObjectWithGhost(ghost);
+                            // Could not apply patch, queue the local client to sync the object
+                            // with the local client's modifications
+                            // https://github.com/Simperium/simperium-android/pull/202
+                            mChannel.queueLocalChange(ghost.getSimperiumKey());
                         }
                     } else {
                         // Apply the new ghost to the unmodified local object

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -975,8 +975,8 @@ public class Bucket<T extends Syncable> {
                             updatedProperties = JSONDiff.apply(updatedProperties, transformedDiff);
 
                         } catch (JSONException | IllegalArgumentException e) {
-                            // could not transform properties
-                            // continue with updated properties
+                            // TODO: Handle failed merge by sending local changes to Simperium
+                            // TODO: Why does sync completely die if this is reached?
                         }
                     }
 

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -648,10 +648,8 @@ public class Bucket<T extends Syncable> {
                             object.setGhost(ghost);
                             updateObject(object);
                         } catch (JSONException | IllegalArgumentException e) {
-                            // Could not apply patch, queue the local client to sync the object
-                            // with the local client's modifications
-                            // https://github.com/Simperium/simperium-android/pull/202
-                            mChannel.queueLocalChange(ghost.getSimperiumKey());
+                            // Could not apply patch, update from the ghost
+                            updateObjectWithGhost(ghost);
                         }
                     } else {
                         // Apply the new ghost to the unmodified local object

--- a/Simperium/src/main/java/com/simperium/util/JSONDiff.java
+++ b/Simperium/src/main/java/com/simperium/util/JSONDiff.java
@@ -43,8 +43,16 @@ public class JSONDiff {
         LinkedList<Patch> patches = dmp.patch_make(source, dmp.diff_fromDelta(source, diff));
 
         String text = (String) dmp.patch_apply(patches, source)[0];
-        String combined = (String) dmp.patch_apply(o_patches, text)[0];
 
+        Object[] appliedPatch = dmp.patch_apply(o_patches, text);
+        boolean[] results = (boolean[]) appliedPatch[1];
+        for (boolean result : results) {
+            if (!result) {
+                throw new JSONException("Could not cleanly transform patch.");
+            }
+        }
+
+        String combined = (String)appliedPatch[0];
         if (text.equals(combined)) {
             // text is the same, return empty diff
             return transformed;


### PR DESCRIPTION
See #201 and #202

Follows the same pattern as simperium-ios.