### PR TITLE
Fix #206: migrate to bintray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Version.java
 # generated files
 bin/
 gen/
+build/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Please provide unit tests for your contributions. Run tests with gradle:
 Unit tests use a mock networking and storage stack so that different components can be tested in isolation. The unit tests should not connect to any external services.
 
 
+## Publish the library to maven central
+
+Replace `CHANGEME` by a valid bintray user/key and run the following command line:
+
+```
+./gradlew assemble publishToMavenLocal bintrayUpload -PbintrayUser=CHANGEME -PbintrayKey=CHANGEME -PdryRun=false
+```
+
 [Android Studio]: http://developer.android.com/sdk/installing/studio.html
 [Gradle]: http://www.gradleware.com
 [Simperium.com]: http://simperium.com

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -105,4 +105,5 @@ publish {
     website = 'https://github.com/Simperium/simperium-android'
     dryRun = 'false'
     autoPublish = 'true'
+    publications = ['clientRelease']
 }

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -100,7 +100,7 @@ publish {
     groupId = 'com.simperium.android'
     uploadName = 'simperium'
     description = 'Android Library for building applications using Simperium'
-    publishVersion = android.defaultConfig.versionName
+    publishVersion = "0.7.2"
     licences = ['MIT']
     website = 'https://github.com/Simperium/simperium-android'
     dryRun = 'false'

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -2,7 +2,6 @@
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
     }
     dependencies { classpath 'com.android.tools.build:gradle:2.0.0' }
 }
@@ -17,13 +16,9 @@ group "com.simperium"
 
 repositories {
     jcenter()
-    mavenCentral()
-    maven { url "http://simperium.github.io/simperium-android" }
-    maven { url "https://maven.google.com" }
 }
 
 android {
-  
     defaultPublishConfig 'clientRelease'
 
     dependencies {
@@ -56,7 +51,6 @@ android {
             dimension "main"
         }
     }
-
 }
 
 task versionConfig(group: "build", description: "Generate version class") {

--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -3,12 +3,15 @@ buildscript {
     repositories {
         jcenter()
     }
-    dependencies { classpath 'com.android.tools.build:gradle:2.0.0' }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.novoda:bintray-release:0.4.0'
+    }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
-apply plugin: 'signing'
+apply plugin: 'com.novoda.bintray-release' // must be applied after your artifact generating plugin (eg. java / com.android.library)
 
 version gitVersion()
 
@@ -91,69 +94,15 @@ public final class Version {
 
 tasks.preBuild.dependsOn versionConfig
 
-afterEvaluate {
-
-    configurations {
-        archives {
-            extendsFrom configurations.default
-        }
-    }
-
-    signing {
-        sign configurations.archives
-    }
-
-    uploadArchives {
-        configuration = configurations.archives
-        repositories {
-            mavenDeployer {
-                beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-                if (project.hasProperty("ossrhUsername") && project.hasProperty("ossrhPassword")) {
-                    repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                      authentication(userName: ossrhUsername, password: ossrhPassword)
-                    }
-
-                    snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                      authentication(userName: ossrhUsername, password: ossrhPassword)
-                    }
-                }
-
-
-                pom.project {
-                    name "Simperium Android Library"
-
-                    groupId 'com.simperium.android'
-                    artifactId 'simperium'
-
-                    packaging 'aar'
-                    description 'Android Library for building applications using Simperium'
-
-                    url 'https://github.com/simperium/simperium-android'
-                    scm {
-                        connection 'scm:git:https://github.com/simperium/simperium-android.git'
-                        developerConnection 'scm:git:https://github.com/simperium/simperium-android.git'
-                        url 'https://github.com/simperium/simperium-android.git'
-                    }
-
-                    licenses {
-                        license {
-                            name 'The MIT License (MIT)'
-                            url 'http://opensource.org/licenses/MIT'
-                        }
-                    }
-
-                    developers {
-
-                        developer {
-                            id 'beaucollins'
-                            name 'Robert Collins'
-                            email 'robert@automattic.com'
-                        }
-
-                    }
-                }
-            }
-        }
-    }
+publish {
+    artifactId = 'simperium'
+    userOrg = 'simperium'
+    groupId = 'com.simperium.android'
+    uploadName = 'simperium'
+    description = 'Android Library for building applications using Simperium'
+    publishVersion = android.defaultConfig.versionName
+    licences = ['MIT']
+    website = 'https://github.com/Simperium/simperium-android'
+    dryRun = 'false'
+    autoPublish = 'true'
 }

--- a/Simperium/src/main/java/com/simperium/android/AsyncAuthClient.java
+++ b/Simperium/src/main/java/com/simperium/android/AsyncAuthClient.java
@@ -1,10 +1,12 @@
 package com.simperium.android;
 
-import org.json.JSONException;
-import org.json.JSONObject;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.util.Log;
 
-import com.koushikdutta.async.http.AsyncHttpClient.JSONObjectCallback;
 import com.koushikdutta.async.http.AsyncHttpClient;
+import com.koushikdutta.async.http.AsyncHttpClient.JSONObjectCallback;
 import com.koushikdutta.async.http.AsyncHttpPost;
 import com.koushikdutta.async.http.AsyncHttpResponse;
 import com.koushikdutta.async.http.body.JSONObjectBody;
@@ -15,14 +17,12 @@ import com.simperium.client.AuthProvider;
 import com.simperium.client.AuthResponseHandler;
 import com.simperium.client.User;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.net.Uri;
-import android.util.Log;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class AsyncAuthClient implements AuthProvider {
 
-    public static final String TAG = "Simperium.AsyncAuthClient";
+    public static final String TAG = "Simperium.AsyncAuth";
 
     private static final String AUTH_URL = "https://auth.simperium.com/1";
     private static final String CREATE_PATH = "create/";
@@ -54,7 +54,7 @@ public class AsyncAuthClient implements AuthProvider {
     @Override
     public void createUser(JSONObject userDetails, AuthResponseHandler handler) {
         try {
-            if (mAuthProvider != null) userDetails.put(PROVIDER_KEY, mAuthProvider);            
+            if (mAuthProvider != null) userDetails.put(PROVIDER_KEY, mAuthProvider);
         } catch (JSONException e) {
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "Unable to add auth provider");
@@ -104,11 +104,11 @@ public class AsyncAuthClient implements AuthProvider {
         AsyncHttpPost request = new AsyncHttpPost(uri);
         request.setBody(new JSONObjectBody(body));
         request.setHeader(API_KEY_HEADER_NAME, mSecret);
-        return request;        
+        return request;
     }
 
     private void sendRequest(String path, JSONObject body, final AuthResponseHandler handler) {
-        
+
         mClient.execute(buildRequest(path, body), new JSONObjectParser(), new JSONObjectCallback() {
             @Override
             public void onCompleted(Exception e, AsyncHttpResponse source, JSONObject result) {

--- a/Simperium/src/support/java/com/simperium/test/MockBucketStore.java
+++ b/Simperium/src/support/java/com/simperium/test/MockBucketStore.java
@@ -19,7 +19,7 @@ import org.json.JSONObject;
 
 public class MockBucketStore<T extends Syncable> implements StorageProvider.BucketStore<T> {
 
-    static public final String TAG = "Simperium.MockBucketStore";
+    static public final String TAG = "Simperium.Mocks";
 
     private Map<String, T> objects = Collections.synchronizedMap(new HashMap<String, T>(32));
 

--- a/Simperium/src/support/java/com/simperium/test/MockConnection.java
+++ b/Simperium/src/support/java/com/simperium/test/MockConnection.java
@@ -12,7 +12,7 @@ import android.util.Log;
 
 public class MockConnection implements Connection {
 
-    public static final String TAG = "Simperium.MockConnection";
+    public static final String TAG = "Simperium.Mocks";
 
     public ConnectionListener listener = new NullListener();
     public Boolean closed = false;
@@ -45,7 +45,7 @@ public class MockConnection implements Connection {
             public void connect(ConnectionListener connectionListener) {
                 MockConnection.this.listener = connectionListener;
                 connectionListener.onConnect(MockConnection.this);
-            }            
+            }
         };
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+allprojects {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+        options.addStringOption('encoding', 'UTF-8')
+    }
+}
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 def gitHash() {
     try {
@@ -30,3 +37,4 @@ def gitDescribe() {
 def gitVersion() {
     (gitDescribe() =~ /^v/).replaceFirst('')
 }
+


### PR DESCRIPTION
Fix #206: migrate to bintray

Notes:
- I had to use bintray plugin version 0.4.0, more recent versions requires to upgrade gradle + gradle android plugin.
- I ignored Javadoc warnings in 0cb56f0 but we might want to fix them (the doc is bundled and uploaded to the maven repo).
- I set up the default publication to `clientRelease` in 65e1787.
- `./gradlew connectedCheck` fails in `develop` and in this branch, I haven't tried to fix them.