### PR TITLE
Add Center Credentials

### DIFF
--- a/Simperium/src/main/res/layout/activity_credentials.xml
+++ b/Simperium/src/main/res/layout/activity_credentials.xml
@@ -21,6 +21,7 @@
 
     <RelativeLayout
         android:clipToPadding="false"
+        android:layout_centerHorizontal="true"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize"
         android:layout_width="@dimen/width_layout"

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.0'
+    '0.9.1'
 }


### PR DESCRIPTION
### Fix
Add the `layout_centerHorizontal` attribute to the `activity_credentials` layout to center the view on large screens.  See the screenshots below for illustration.

Before|After
-|-
![1568940731](https://user-images.githubusercontent.com/3827611/65290985-b7221500-db0e-11e9-9d7b-53991ce086db.png)|![1568940230](https://user-images.githubusercontent.com/3827611/65290988-bb4e3280-db0e-11e9-8cf5-76d5fee05736.png)
![1568940734](https://user-images.githubusercontent.com/3827611/65290995-c30dd700-db0e-11e9-8075-2da3bd9fab25.png)|![1568940281](https://user-images.githubusercontent.com/3827611/65290999-c4d79a80-db0e-11e9-8c82-75b03d3bf6d4.png)

### Test
Simperium does not have a stand-alone application so there is nothing to run directly on a device or emulator other than tests. The following commands can be run from the project's root directory while a device or emulator is connected and ensure the tests pass.

```
./gradlew connectedCheck
./gradlew cAT
```

### Review
Only one developer and one designer are required to review these changes, but anyone can perform the review.