### PR TITLE
Stop Splitting Surrogates

### DIFF
--- a/Simperium/src/main/java/name/fraser/neil/plaintext/diff_match_patch.java
+++ b/Simperium/src/main/java/name/fraser/neil/plaintext/diff_match_patch.java
@@ -1429,7 +1429,22 @@ public class diff_match_patch {
    */
   public String diff_toDelta(LinkedList<Diff> diffs) {
     StringBuilder text = new StringBuilder();
+    char lastEnd = 0;
+    boolean isFirst = true;
     for (Diff aDiff : diffs) {
+      char thisTop = aDiff.text.charAt(0);
+      char thisEnd = aDiff.text.charAt(aDiff.text.length() - 1);
+      if (Character.isHighSurrogate(thisEnd)) {
+        aDiff.text = aDiff.text.substring(0, aDiff.text.length() - 1);
+      }
+      if (! isFirst && Character.isHighSurrogate(lastEnd) && Character.isLowSurrogate(thisTop)) {
+        aDiff.text = lastEnd + aDiff.text;
+      }
+      isFirst = false;
+      lastEnd = thisEnd;
+      if ( aDiff.text.isEmpty() ) {
+        continue;
+      }
       switch (aDiff.operation) {
       case INSERT:
         try {

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.1'
+    '0.9.2'
 }


### PR DESCRIPTION
### Fix
This is the Android counterpart of https://github.com/Simperium/node-simperium/pull/91 and https://github.com/Simperium/simperium-ios/pull/582.  These changes stop the splitting of surrogate pairs, which resulted in corrupted data in note content.

### Review
Only one developer is required to review these changes, but anyone can perform the review.