### PR TITLE
Object Backup Store

### DIFF
--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -351,6 +351,12 @@ public class Bucket<T extends Syncable> {
                         return;
                     }
 
+                    // Put object in backup store if not already there so that queued local deletion
+                    // will send change event and remove object from server and all other platforms.
+                    if (mBackupStore.get(object.getSimperiumKey()) == null) {
+                        mBackupStore.put(object.getSimperiumKey(), object);
+                    }
+
                     mChannel.queueLocalDeletion(object);
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.2'
+    '0.9.3'
 }


### PR DESCRIPTION
### Fix
Add putting the object being deleted into the backup store before it is removed from storage so that a change event will be sent once the queued local deletion occurs and the object will be removed from all platforms.  Without these changes, objects created outside of Android were not put in the backup store.  When the queued local deletion was executed, the object could not be found and a change event was not sent.  Therefore, the object was removed from the Android client, but not from any other platform.  These changes ensure the object exists in the backup store and the change event is sent.

### Test
The best way to test these changes is to point your local Simplenote repository to your local Simperium repository.  Contact me for details.

### Review
Only one developer is required to review these changes, but anyone can perform the review.