### PR TITLE
Ignore corrupted ghosts

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/GhostStore.java
+++ b/Simperium/src/main/java/com/simperium/android/GhostStore.java
@@ -11,6 +11,7 @@ import com.simperium.client.GhostMissingException;
 import com.simperium.client.GhostStorageProvider;
 import com.simperium.util.Logger;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class GhostStore implements GhostStorageProvider {
@@ -127,7 +128,12 @@ public class GhostStore implements GhostStorageProvider {
         Ghost ghost = null;
         if (cursor.getCount() > 0) {
             cursor.moveToFirst();
-            ghost = new Ghost(cursor.getString(1), cursor.getInt(2), deserializeGhostData(cursor.getString(3)));
+            try {
+                JSONObject ghostData = new JSONObject(cursor.getString(3));
+                ghost = new Ghost(cursor.getString(1), cursor.getInt(2), ghostData);
+            } catch (org.json.JSONException e){
+                ghost = null;
+            }
         }
         cursor.close();
         if (ghost == null) {


### PR DESCRIPTION
There are occasions where the stored contents of a ghost may be corrupted
outside of the control of this library. One such occasion was discovered when
sqlite was improperly converting malformed UTF-16 data into UTF-8. In these
cases we risk treating corrupted data as valid and causing more harm to the
ghost and bucket value. Additionally we risk corrupting the JSON structure
stored in the database which can lead to crashes when reading or using it.

In this patch we're performing one simple validation to make sure that we don't
attempt to use a ghost which we cannot parse as JSON. Should the occasion arise
then the library should attempt to retrieve the latest ghost from the server
and start fresh with its processing.

Although it looks like this patch may introduce a vector for losing changes it's
actually closing a vector for an app crash; the data would have never made it in
the first place.