### PR TITLE
Update Websocket Threading

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
+++ b/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
@@ -15,9 +15,9 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
 
     public static final String TAG = "Simperium.AsyncWebSocketProvider";
 
-    protected final AsyncHttpClient mAsyncClient;
-    protected final String mAppId;
-    protected final String mSessionId;
+    private final AsyncHttpClient mAsyncClient;
+    private final String mAppId;
+    private final String mSessionId;
 
     AsyncWebSocketProvider(String appId, String sessionId, AsyncHttpClient asyncClient) {
         mAppId = appId;

--- a/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
+++ b/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
@@ -12,7 +12,6 @@ import com.koushikdutta.async.http.WebSocket;
 import java.io.IOException;
 
 class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
-
     public static final String TAG = "Simperium.AsyncWebSocketProvider";
 
     private final AsyncHttpClient mAsyncClient;
@@ -27,15 +26,12 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
 
     @Override
     public void connect(final WebSocketManager.ConnectionListener listener) {
-
         Uri uri = Uri.parse(String.format(AndroidClient.WEBSOCKET_URL, mAppId));
-
         AsyncHttpRequest request = new AsyncHttpGet(uri);
         request.setHeader(AndroidClient.USER_AGENT_HEADER, mSessionId);
 
         // Protocol is null
         mAsyncClient.websocket(request, null, new WebSocketConnectCallback() {
-
             @Override
             public void onCompleted(Exception ex, final WebSocket webSocket) {
                 if (ex != null) {
@@ -49,7 +45,6 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
                 }
 
                 final WebSocketManager.Connection connection = new WebSocketManager.Connection() {
-
                     @Override
                     public void close() {
                         webSocket.close();
@@ -62,21 +57,17 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
                 };
 
                 webSocket.setStringCallback(new WebSocket.StringCallback() {
-
                    @Override
                    public void onStringAvailable(String s) {
                        listener.onMessage(s);
                    }
-
                 });
 
                 webSocket.setEndCallback(new CompletedCallback() {
-
                     @Override
                     public void onCompleted(Exception ex) {
                         listener.onDisconnect(ex);
                     }
-
                 });
 
                 webSocket.setClosedCallback(new CompletedCallback() {
@@ -87,10 +78,7 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
                 });
 
                 listener.onConnect(connection);
-
             }
-
         });
     }
-
 }

--- a/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
+++ b/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
@@ -1,15 +1,13 @@
 package com.simperium.android;
 
+import android.net.Uri;
+
 import com.koushikdutta.async.callback.CompletedCallback;
 import com.koushikdutta.async.http.AsyncHttpClient;
-import com.koushikdutta.async.http.AsyncHttpRequest;
-import com.koushikdutta.async.http.AsyncHttpGet;
 import com.koushikdutta.async.http.AsyncHttpClient.WebSocketConnectCallback;
+import com.koushikdutta.async.http.AsyncHttpGet;
+import com.koushikdutta.async.http.AsyncHttpRequest;
 import com.koushikdutta.async.http.WebSocket;
-
-import android.net.Uri;
-import android.os.Handler;
-import android.os.Looper;
 
 import java.io.IOException;
 
@@ -17,16 +15,14 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
 
     public static final String TAG = "Simperium.AsyncWebSocketProvider";
 
+    protected final AsyncHttpClient mAsyncClient;
     protected final String mAppId;
     protected final String mSessionId;
-    protected final AsyncHttpClient mAsyncClient;
-    protected final Handler mHandler;
 
     AsyncWebSocketProvider(String appId, String sessionId, AsyncHttpClient asyncClient) {
         mAppId = appId;
         mAsyncClient = asyncClient;
         mSessionId = sessionId;
-        mHandler = new Handler(Looper.getMainLooper());
     }
 
     @Override
@@ -56,28 +52,13 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
 
                     @Override
                     public void close() {
-                        mHandler.post(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                webSocket.close();
-                            }
-
-                        });
+                        webSocket.close();
                     }
 
                     @Override
                     public void send(final String message) {
-                        mHandler.post(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                webSocket.send(message);
-                            }
-
-                        });
+                        webSocket.send(message);
                     }
-
                 };
 
                 webSocket.setStringCallback(new WebSocket.StringCallback() {

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.4'
+    '0.9.5'
 }


### PR DESCRIPTION
### Fix
Simplenote is receiving ANR (i.e. app-not-responding) reports due to the `AsyncWebSocketProvider` class.  `AsyncWebSocketProvider` was updated long ago to run on the main looper to fix a WordPress Android bug.  Simperium is no longer being used in WordPress Android and the main looper is causing ANR issues in Simplenote.  These changes update the `AsyncWebSocketProvider` class by removing the main looper usage to eliminate the ANR issues.

### Test
Simperium does not have a stand-alone application so there is nothing to run directly on a device or emulator other than tests. The following commands can be run from the project's root directory while a device or emulator is connected and ensure the tests pass.

```
./gradlew connectedCheck
./gradlew cAT
```
These changes can also be smoke tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.

### Review
Only one developer is required to review these changes, but anyone can perform the review.