### PR TITLE
Update Bottom Sheet

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/LoginBottomSheetDialogFragment.java
+++ b/Simperium/src/main/java/com/simperium/android/LoginBottomSheetDialogFragment.java
@@ -5,12 +5,14 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatButton;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.simperium.R;
 
 public class LoginBottomSheetDialogFragment extends SimperiumBottomSheetDialogFragment {
@@ -56,17 +58,21 @@ public class LoginBottomSheetDialogFragment extends SimperiumBottomSheetDialogFr
         if (getDialog() != null) {
             getDialog().setContentView(layout);
 
-            // Set peek height to full height of view to avoid buttons being off screen when
-            // bottom sheet is shown with small screen height (e.g. landscape orientation).
-            final BottomSheetBehavior behavior = BottomSheetBehavior.from((View) layout.getParent());
-            getDialog().setOnShowListener(
-                new DialogInterface.OnShowListener() {
-                    @Override
-                    public void onShow(DialogInterface dialog) {
-                        behavior.setPeekHeight(layout.getHeight());
+            // Set peek height to full height of view (i.e. set STATE_EXPANDED) to avoid buttons
+            // being off screen when bottom sheet is shown.
+            getDialog().setOnShowListener(new DialogInterface.OnShowListener() {
+                @Override
+                public void onShow(DialogInterface dialogInterface) {
+                    BottomSheetDialog bottomSheetDialog = (BottomSheetDialog) dialogInterface;
+                    FrameLayout bottomSheet = bottomSheetDialog.findViewById(com.google.android.material.R.id.design_bottom_sheet);
+
+                    if (bottomSheet != null) {
+                        BottomSheetBehavior behavior = BottomSheetBehavior.from(bottomSheet);
+                        behavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+                        behavior.setSkipCollapsed(true);
                     }
                 }
-            );
+            });
         }
 
         return super.onCreateView(inflater, container, savedInstanceState);

--- a/Simperium/src/main/java/com/simperium/android/SimperiumBottomSheetDialogFragment.java
+++ b/Simperium/src/main/java/com/simperium/android/SimperiumBottomSheetDialogFragment.java
@@ -2,9 +2,12 @@ package com.simperium.android;
 
 import android.app.Dialog;
 import android.os.Bundle;
-import android.view.WindowManager;
+import android.view.Gravity;
+import android.view.ViewParent;
+import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
 
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
@@ -32,11 +35,22 @@ public class SimperiumBottomSheetDialogFragment extends BottomSheetDialogFragmen
             int dp = (int) getDialog().getContext().getResources().getDimension(R.dimen.width_layout);
 
             if (dp > 0) {
-                WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams();
-                layoutParams.copyFrom(getDialog().getWindow() != null ? getDialog().getWindow().getAttributes() : null);
-                layoutParams.width = dp;
-                layoutParams.height = WindowManager.LayoutParams.MATCH_PARENT;
-                getDialog().getWindow().setAttributes(layoutParams);
+                FrameLayout bottomSheetLayout = getDialog().findViewById(com.google.android.material.R.id.design_bottom_sheet);
+
+                if (bottomSheetLayout != null) {
+                    ViewParent bottomSheetParent = bottomSheetLayout.getParent();
+
+                    if (bottomSheetParent instanceof CoordinatorLayout) {
+                        CoordinatorLayout.LayoutParams coordinatorLayoutParams = (CoordinatorLayout.LayoutParams) bottomSheetLayout.getLayoutParams();
+                        coordinatorLayoutParams.width = dp;
+                        bottomSheetLayout.setLayoutParams(coordinatorLayoutParams);
+
+                        CoordinatorLayout coordinatorLayout = (CoordinatorLayout) bottomSheetParent;
+                        FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) coordinatorLayout.getLayoutParams();
+                        layoutParams.gravity = Gravity.CENTER_HORIZONTAL;
+                        coordinatorLayout.setLayoutParams(layoutParams);
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.5'
+    '0.9.6'
 }


### PR DESCRIPTION
### Fix
The bottom sheet dialog shown after tapping the login button on the authentication screen hides the navigation bar buttons on large screen devices (e.g. tablets).  These changes update the view to which the custom layout parameters are applied in the bottom sheet base class.  Consequently, the peek height must be updated and the collapsed state must be disabled in all inherited classes.  See the screenshots below for illustration.

![update_bottom_sheet_login_portrait](https://user-images.githubusercontent.com/3827611/73599346-a42d4180-44ff-11ea-931b-3a2f5c6c653d.png)

![update_bottom_sheet_login_landscape](https://user-images.githubusercontent.com/3827611/73599347-a55e6e80-44ff-11ea-88db-9e9ba07c8ddc.png)

### Test
These changes are best tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.  In the Simplenote app, follow the steps below.

0. Clear app data.
1. Tap ***Log In*** button.
2. Notice navigation bar buttons are visible.

### Review
Only one developer and one designer required to review these changes, but anyone can perform the review.