### PR TITLE
Update Password Policy

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 import static com.simperium.android.AuthenticationActivity.EXTRA_IS_LOGIN;
 
 public class CredentialsActivity extends AppCompatActivity {
-    private static final Pattern PATTERN_EXCLUDE_NEWLINES_TABS = Pattern.compile("[^\n\t]+");
+    private static final Pattern PATTERN_NEWLINES_TABS = Pattern.compile("[\n\t]");
     private static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
     private static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
     private static final String STATE_EMAIL = "STATE_EMAIL";
@@ -321,7 +321,7 @@ public class CredentialsActivity extends AppCompatActivity {
     }
 
     private boolean isValidPassword(String password) {
-        return isValidPasswordLength(mIsLogin) && PATTERN_EXCLUDE_NEWLINES_TABS.matcher(password).find();
+        return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_TABS.matcher(password).find();
     }
 
     private boolean isValidPasswordLength(boolean isLogin) {

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -47,7 +47,7 @@ public class CredentialsActivity extends AppCompatActivity {
     private static final String STATE_PASSWORD = "STATE_PASSWORD";
     private static final int DELAY_AUTOMATE_LOGIN = 600;
     private static final int PASSWORD_LENGTH_LOGIN = 4;
-    private static final int PASSWORD_LENGTH_SIGNUP = 6;
+    private static final int PASSWORD_LENGTH_MINIMUM = 8;
 
     protected ProgressDialogFragment mProgressDialogFragment;
 
@@ -323,7 +323,7 @@ public class CredentialsActivity extends AppCompatActivity {
         return mInputPassword.getEditText() != null &&
             (mIsLogin ?
                 mInputPassword.getEditText().getText().toString().length() >= PASSWORD_LENGTH_LOGIN :
-                mInputPassword.getEditText().getText().toString().length() >= PASSWORD_LENGTH_SIGNUP
+                mInputPassword.getEditText().getText().toString().length() >= PASSWORD_LENGTH_MINIMUM
             );
     }
 
@@ -386,7 +386,7 @@ public class CredentialsActivity extends AppCompatActivity {
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);
             mSimperium.authorizeUser(email, password, mAuthListener);
         } else {
-            showDialogError(getString(R.string.simperium_dialog_message_password, PASSWORD_LENGTH_LOGIN));
+            showDialogError(getString(R.string.simperium_dialog_message_password, PASSWORD_LENGTH_MINIMUM));
         }
     }
 
@@ -400,7 +400,7 @@ public class CredentialsActivity extends AppCompatActivity {
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);
             mSimperium.createUser(email, password, mAuthListener);
         } else {
-            showDialogError(getString(R.string.simperium_dialog_message_password, PASSWORD_LENGTH_SIGNUP));
+            showDialogError(getString(R.string.simperium_dialog_message_password, PASSWORD_LENGTH_MINIMUM));
         }
     }
 }

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -376,11 +376,33 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
+    private void showDialogErrorLoginReset() {
+        hideDialogProgress();
+        Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
+        new AlertDialog.Builder(context)
+            .setTitle(R.string.simperium_dialog_title_error)
+            .setMessage(getString(R.string.simperium_dialog_message_login_reset, PASSWORD_LENGTH_MINIMUM))
+            .setNegativeButton(android.R.string.cancel, null)
+            .setPositiveButton(R.string.simperium_button_login_reset,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Uri uri = Uri.parse(getString(R.string.simperium_dialog_button_reset_url, getEditTextString(mInputEmail)));
+                        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+                        startActivity(intent);
+                    }
+                }
+            )
+            .show();
+    }
+
     private void startLogin() {
         final String email = getEditTextString(mInputEmail).trim();
         final String password = getEditTextString(mInputPassword).trim();
 
-        if (isValidPassword(password)) {
+        if (!isValidPasswordLength()) {
+            showDialogErrorLoginReset();
+        } else if (isValidPassword(password)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -311,6 +311,11 @@ public class CredentialsActivity extends AppCompatActivity {
         }
     }
 
+    private boolean isEmailPasswordMatch() {
+        return mInputEmail.getEditText() != null && mInputPassword.getEditText() != null &&
+            mInputEmail.getEditText().getText().toString().contentEquals(mInputPassword.getEditText().getText().toString());
+    }
+
     private boolean isValidEmail(String text) {
         return Patterns.EMAIL_ADDRESS.matcher(text).matches();
     }
@@ -401,7 +406,7 @@ public class CredentialsActivity extends AppCompatActivity {
         final String password = getEditTextString(mInputPassword).trim();
 
         // Use false in isValidPasswordLength() to check if password meets new minimum length requirement.
-        if (!isValidPasswordLength(false)) {
+        if (!isValidPasswordLength(false) || isEmailPasswordMatch()) {
             showDialogErrorLoginReset();
         } else if (isValidPassword(password)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));
@@ -417,7 +422,7 @@ public class CredentialsActivity extends AppCompatActivity {
         final String email = getEditTextString(mInputEmail).trim();
         final String password = getEditTextString(mInputPassword).trim();
 
-        if (isValidPassword(password)) {
+        if (isValidPassword(password) && !isEmailPasswordMatch()) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_signing_up));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -165,7 +165,7 @@ public class CredentialsActivity extends AppCompatActivity {
                 new View.OnFocusChangeListener() {
                     @Override
                     public void onFocusChange(View view, boolean hasFocus) {
-                        if (!hasFocus && !isValidEmail(mInputEmail.getEditText().getText().toString())) {
+                        if (!hasFocus && !isValidEmail(getEditTextString(mInputEmail))) {
                             mInputEmail.setError(getString(R.string.simperium_error_email));
                         } else {
                             mInputEmail.setError("");
@@ -321,15 +321,14 @@ public class CredentialsActivity extends AppCompatActivity {
     // - Does not match email address
     private boolean isValidPassword(String password) {
         return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_TABS.matcher(password).find() &&
-            (mInputEmail.getEditText() != null && mInputPassword.getEditText() != null &&
-            !mInputEmail.getEditText().getText().toString().contentEquals(mInputPassword.getEditText().getText().toString()));
+            !getEditTextString(mInputEmail).contentEquals(getEditTextString(mInputPassword));
     }
 
     private boolean isValidPasswordLength(boolean isLogin) {
         return mInputPassword.getEditText() != null &&
             (isLogin ?
-                mInputPassword.getEditText().getText().toString().length() >= PASSWORD_LENGTH_LOGIN :
-                mInputPassword.getEditText().getText().toString().length() >= PASSWORD_LENGTH_MINIMUM
+                getEditTextString(mInputPassword).length() >= PASSWORD_LENGTH_LOGIN :
+                getEditTextString(mInputPassword).length() >= PASSWORD_LENGTH_MINIMUM
             );
     }
 
@@ -337,7 +336,7 @@ public class CredentialsActivity extends AppCompatActivity {
         mButton.setEnabled(
             mInputEmail.getEditText() != null &&
             mInputPassword.getEditText() != null &&
-            isValidEmail(mInputEmail.getEditText().getText().toString()) &&
+            isValidEmail(getEditTextString(mInputEmail)) &&
             isValidPasswordLength(mIsLogin)
         );
     }

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -405,16 +405,14 @@ public class CredentialsActivity extends AppCompatActivity {
         final String email = getEditTextString(mInputEmail).trim();
         final String password = getEditTextString(mInputPassword).trim();
 
-        // Use false in isValidPasswordLength() to check if password meets new minimum length requirement.
-        if (!isValidPasswordLength(false) || isEmailPasswordMatch()) {
-            showDialogErrorLoginReset();
-        } else if (isValidPassword(password)) {
+        // Use isValidPasswordLength(false) to check if password meets PASSWORD_LENGTH_MINIMUM.
+        if (isValidPassword(password) && !isEmailPasswordMatch() && isValidPasswordLength(false)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);
             mSimperium.authorizeUser(email, password, mAuthListener);
         } else {
-            showDialogError(getString(R.string.simperium_dialog_message_password, PASSWORD_LENGTH_MINIMUM));
+            showDialogErrorLoginReset();
         }
     }
 

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 import static com.simperium.android.AuthenticationActivity.EXTRA_IS_LOGIN;
 
 public class CredentialsActivity extends AppCompatActivity {
-    private static final Pattern PATTERN_WHITESPACE = Pattern.compile("(\\s)");
+    private static final Pattern PATTERN_EXCLUDE_NEWLINES_TABS = Pattern.compile("[^\n\t]+");
     private static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
     private static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
     private static final String STATE_EMAIL = "STATE_EMAIL";
@@ -316,7 +316,7 @@ public class CredentialsActivity extends AppCompatActivity {
     }
 
     private boolean isValidPassword(String password) {
-        return isValidPasswordLength() && !PATTERN_WHITESPACE.matcher(password).find();
+        return isValidPasswordLength() && PATTERN_EXCLUDE_NEWLINES_TABS.matcher(password).find();
     }
 
     private boolean isValidPasswordLength() {

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -319,9 +319,8 @@ public class CredentialsActivity extends AppCompatActivity {
     // - Meets minimum length requirement based on login (PASSWORD_LENGTH_LOGIN) and signup (PASSWORD_LENGTH_MINIMUM)
     // - Does not have new lines or tabs (PATTERN_NEWLINES_TABS)
     // - Does not match email address
-    private boolean isValidPassword(String password) {
-        return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_TABS.matcher(password).find() &&
-            !getEditTextString(mInputEmail).contentEquals(getEditTextString(mInputPassword));
+    private boolean isValidPassword(String email, String password) {
+        return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_TABS.matcher(password).find() && !email.contentEquals(password);
     }
 
     private boolean isValidPasswordLength(boolean isLogin) {
@@ -406,7 +405,7 @@ public class CredentialsActivity extends AppCompatActivity {
         final String password = getEditTextString(mInputPassword);
 
         // Use isValidPasswordLength(false) to check if password meets PASSWORD_LENGTH_MINIMUM.
-        if (isValidPassword(password) && isValidPasswordLength(false)) {
+        if (isValidPassword(email, password) && isValidPasswordLength(false)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);
@@ -420,7 +419,7 @@ public class CredentialsActivity extends AppCompatActivity {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 
-        if (isValidPassword(password)) {
+        if (isValidPassword(email, password)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_signing_up));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -311,17 +311,18 @@ public class CredentialsActivity extends AppCompatActivity {
         }
     }
 
-    private boolean isEmailPasswordMatch() {
-        return mInputEmail.getEditText() != null && mInputPassword.getEditText() != null &&
-            mInputEmail.getEditText().getText().toString().contentEquals(mInputPassword.getEditText().getText().toString());
-    }
-
     private boolean isValidEmail(String text) {
         return Patterns.EMAIL_ADDRESS.matcher(text).matches();
     }
 
+    // Password is valid if:
+    // - Meets minimum length requirement based on login (PASSWORD_LENGTH_LOGIN) and signup (PASSWORD_LENGTH_MINIMUM)
+    // - Does not have new lines or tabs (PATTERN_NEWLINES_TABS)
+    // - Does not match email address
     private boolean isValidPassword(String password) {
-        return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_TABS.matcher(password).find();
+        return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_TABS.matcher(password).find() &&
+            (mInputEmail.getEditText() != null && mInputPassword.getEditText() != null &&
+            !mInputEmail.getEditText().getText().toString().contentEquals(mInputPassword.getEditText().getText().toString()));
     }
 
     private boolean isValidPasswordLength(boolean isLogin) {
@@ -406,7 +407,7 @@ public class CredentialsActivity extends AppCompatActivity {
         final String password = getEditTextString(mInputPassword);
 
         // Use isValidPasswordLength(false) to check if password meets PASSWORD_LENGTH_MINIMUM.
-        if (isValidPassword(password) && !isEmailPasswordMatch() && isValidPasswordLength(false)) {
+        if (isValidPassword(password) && isValidPasswordLength(false)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);
@@ -420,7 +421,7 @@ public class CredentialsActivity extends AppCompatActivity {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 
-        if (isValidPassword(password) && !isEmailPasswordMatch()) {
+        if (isValidPassword(password)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_signing_up));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -204,7 +204,7 @@ public class CredentialsActivity extends AppCompatActivity {
                     public void onFocusChange(View view, boolean hasFocus) {
                         if (hasFocus) {
                             mInputPassword.setError("");
-                        } else if (!isValidPasswordLength()) {
+                        } else if (!isValidPasswordLength(mIsLogin)) {
                             mInputPassword.setError(getString(R.string.simperium_error_password));
                         }
                     }
@@ -316,12 +316,12 @@ public class CredentialsActivity extends AppCompatActivity {
     }
 
     private boolean isValidPassword(String password) {
-        return isValidPasswordLength() && PATTERN_EXCLUDE_NEWLINES_TABS.matcher(password).find();
+        return isValidPasswordLength(mIsLogin) && PATTERN_EXCLUDE_NEWLINES_TABS.matcher(password).find();
     }
 
-    private boolean isValidPasswordLength() {
+    private boolean isValidPasswordLength(boolean isLogin) {
         return mInputPassword.getEditText() != null &&
-            (mIsLogin ?
+            (isLogin ?
                 mInputPassword.getEditText().getText().toString().length() >= PASSWORD_LENGTH_LOGIN :
                 mInputPassword.getEditText().getText().toString().length() >= PASSWORD_LENGTH_MINIMUM
             );
@@ -332,7 +332,7 @@ public class CredentialsActivity extends AppCompatActivity {
             mInputEmail.getEditText() != null &&
             mInputPassword.getEditText() != null &&
             isValidEmail(mInputEmail.getEditText().getText().toString()) &&
-            isValidPasswordLength()
+            isValidPasswordLength(mIsLogin)
         );
     }
 
@@ -400,7 +400,8 @@ public class CredentialsActivity extends AppCompatActivity {
         final String email = getEditTextString(mInputEmail).trim();
         final String password = getEditTextString(mInputPassword).trim();
 
-        if (!isValidPasswordLength()) {
+        // Use false in isValidPasswordLength() to check if password meets new minimum length requirement.
+        if (!isValidPasswordLength(false)) {
             showDialogErrorLoginReset();
         } else if (isValidPassword(password)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -402,8 +402,8 @@ public class CredentialsActivity extends AppCompatActivity {
     }
 
     private void startLogin() {
-        final String email = getEditTextString(mInputEmail).trim();
-        final String password = getEditTextString(mInputPassword).trim();
+        final String email = getEditTextString(mInputEmail);
+        final String password = getEditTextString(mInputPassword);
 
         // Use isValidPasswordLength(false) to check if password meets PASSWORD_LENGTH_MINIMUM.
         if (isValidPassword(password) && !isEmailPasswordMatch() && isValidPasswordLength(false)) {
@@ -417,8 +417,8 @@ public class CredentialsActivity extends AppCompatActivity {
     }
 
     private void startSignup() {
-        final String email = getEditTextString(mInputEmail).trim();
-        final String password = getEditTextString(mInputPassword).trim();
+        final String email = getEditTextString(mInputEmail);
+        final String password = getEditTextString(mInputPassword);
 
         if (isValidPassword(password) && !isEmailPasswordMatch()) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_signing_up));

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="simperium_dialog_message_login">Could not log in with the provided email address and password.</string>
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
-    <string name="simperium_dialog_message_password">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
+    <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simperium account.</string>
     <string name="simperium_dialog_progress_logging_in">Logging in&#8230;</string>

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -7,8 +7,11 @@
     <string name="simperium_button_login">Log In</string>
     <string name="simperium_button_login_email">Log In with Email</string>
     <string name="simperium_button_login_other">Log In with Other</string>
+    <string name="simperium_button_login_reset">Reset</string>
     <string name="simperium_button_signup">Sign Up</string>
+    <string name="simperium_dialog_button_reset_url">@string/simperium_footer_login_url</string>
     <string name="simperium_dialog_message_login">Could not log in with the provided email address and password.</string>
+    <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
     <string name="simperium_dialog_message_password">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.6'
+    '0.9.7'
 }


### PR DESCRIPTION
### Fix
Update the password policy requirements to the following:
- Password cannot match username
- Minimum of 8 characters
- No new lines
- No tabs

### Test
These changes are best tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.  In order to test the login password length updates, change your Simplenote password to more than four and less than eight characters.  In the Simplenote app, follow the steps below.

0. Clear app data.
1. Tap ***Sign Up*** button.
2. Enter email address in ***Email*** field.
3. Notice ***Sign Up*** button is disabled.
4. Enter email address, new lines, or tabs in ***Password*** field.
5. Notice ***Sign Up*** button is enabled after eight characters are input.
6. Tap ***Sign Up*** button.
7. Notice ***Error*** dialog with password requirements is shown.
8. Tap ***OK*** button in dialog.
9. Tap back arrow in top app bar.
10. Tap ***Log In*** button.
11. Tap ***Log In with Email*** button.
12. Enter email address in ***Email*** field.
13. Notice ***Log In*** button is disabled.
14. Enter password of more than four and less than eight characters in ***Password*** field.
15. Notice ***Log In*** button is enabled after four characters are input.
16. Tap ***Log In*** button.
17. Notice ***Error*** dialog with password requirements is shown.
18. Tap ***Reset*** button in dialog.
19. Notice external browser is opened showing the https://app.simplenote.com/forgot/ page.

### Review
Only one developer is required to review these changes, but anyone can perform the review.