### PR TITLE
Update Password Policy

### DIFF
--- a/Simperium/src/main/java/com/simperium/Simperium.java
+++ b/Simperium/src/main/java/com/simperium/Simperium.java
@@ -173,8 +173,8 @@ public class Simperium implements User.StatusChangeListener {
         user.setCredentials(email, password);
         AuthResponseListener wrapper = new AuthResponseListenerWrapper(listener){
             @Override
-            public void onSuccess(User user){
-                super.onSuccess(user);
+            public void onSuccess(User user, String userId, String token){
+                super.onSuccess(user, userId, token);
                 notifyOnUserCreatedListener(user);
             }
         };
@@ -233,9 +233,9 @@ public class Simperium implements User.StatusChangeListener {
         }
 
         @Override
-        public void onSuccess(User user) {
+        public void onSuccess(User user, String userId, String token) {
             mAuthProvider.saveUser(user);
-            mListener.onSuccess(user);
+            mListener.onSuccess(user, userId, token);
         }
 
         @Override

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -97,8 +97,19 @@ public class CredentialsActivity extends AppCompatActivity {
                             inputMethodManager.hideSoftInputFromWindow(mButton.getWindowToken(), 0);
                         }
 
-                        setResult(RESULT_OK);
-                        finish();
+                        // Use isValidPasswordLength(false) to check if password meets PASSWORD_LENGTH_MINIMUM.
+                        if (isValidPassword(user.getEmail(), user.getPassword()) && isValidPasswordLength(false)) {
+                            user.setStatus(User.Status.AUTHORIZED);
+                            user.setAccessToken(token);
+                            user.setUserId(userId);
+                            setResult(RESULT_OK);
+                            finish();
+                        } else {
+                            user.setStatus(User.Status.NOT_AUTHORIZED);
+                            user.setAccessToken("");
+                            user.setUserId("");
+                            showDialogErrorLoginReset();
+                        }
                     }
                 }
             );

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -41,6 +41,7 @@ import static com.simperium.android.AuthenticationActivity.EXTRA_IS_LOGIN;
 
 public class CredentialsActivity extends AppCompatActivity {
     private static final Pattern PATTERN_NEWLINES_TABS = Pattern.compile("[\n\t]");
+    private static final Pattern PATTERN_WHITESPACE = Pattern.compile("(\\s)");
     private static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
     private static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
     private static final String STATE_EMAIL = "STATE_EMAIL";
@@ -331,6 +332,10 @@ public class CredentialsActivity extends AppCompatActivity {
             );
     }
 
+    private boolean isValidPasswordLogin(String password) {
+        return isValidPasswordLength(mIsLogin) && !PATTERN_WHITESPACE.matcher(password).find();
+    }
+
     private void setButtonState() {
         mButton.setEnabled(
             mInputEmail.getEditText() != null &&
@@ -404,14 +409,13 @@ public class CredentialsActivity extends AppCompatActivity {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 
-        // Use isValidPasswordLength(false) to check if password meets PASSWORD_LENGTH_MINIMUM.
-        if (isValidPassword(email, password) && isValidPasswordLength(false)) {
+        if (isValidPasswordLogin(password)) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);
             mSimperium.authorizeUser(email, password, mAuthListener);
         } else {
-            showDialogErrorLoginReset();
+            showDialogError(getString(R.string.simperium_dialog_message_password_login, PASSWORD_LENGTH_LOGIN));
         }
     }
 

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -35,9 +35,12 @@ import com.simperium.client.User;
 import com.simperium.util.Logger;
 import com.simperium.util.NetworkUtil;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.regex.Pattern;
 
 import static com.simperium.android.AuthenticationActivity.EXTRA_IS_LOGIN;
+import static org.apache.http.protocol.HTTP.UTF_8;
 
 public class CredentialsActivity extends AppCompatActivity {
     private static final Pattern PATTERN_NEWLINES_TABS = Pattern.compile("[\n\t]");
@@ -407,9 +410,13 @@ public class CredentialsActivity extends AppCompatActivity {
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        Uri uri = Uri.parse(getString(R.string.simperium_dialog_button_reset_url, getEditTextString(mInputEmail)));
-                        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                        startActivity(intent);
+                        try {
+                            Uri uri = Uri.parse(getString(R.string.simperium_dialog_button_reset_url, URLEncoder.encode(getEditTextString(mInputEmail), UTF_8)));
+                            Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+                            startActivity(intent);
+                        } catch (UnsupportedEncodingException e) {
+                            throw new RuntimeException("Unable to parse URL", e);
+                        }
                     }
                 }
             )

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -84,7 +84,7 @@ public class CredentialsActivity extends AppCompatActivity {
         }
 
         @Override
-        public void onSuccess(final User user) {
+        public void onSuccess(final User user, final String userId, final String token) {
             runOnUiThread(
                 new Runnable() {
                     @Override

--- a/Simperium/src/main/java/com/simperium/client/AuthResponseHandler.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthResponseHandler.java
@@ -26,7 +26,7 @@ public class AuthResponseHandler {
         }
 
         mUser.setStatus(User.Status.AUTHORIZED);
-        mListener.onSuccess(mUser);
+        mListener.onSuccess(mUser, mUser.getUserId(), mUser.getAccessToken());
     }
 
     public void onError(AuthException error){

--- a/Simperium/src/main/java/com/simperium/client/AuthResponseHandler.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthResponseHandler.java
@@ -2,35 +2,26 @@ package com.simperium.client;
 
 import com.simperium.util.AuthUtil;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 public class AuthResponseHandler {
-
     private AuthResponseListener mListener;
     private User mUser;
 
-    public AuthResponseHandler(User user, AuthResponseListener listener){
+    public AuthResponseHandler(User user, AuthResponseListener listener) {
         mUser = user;
         mListener = listener;
     }
 
     public void onResponse(JSONObject response){
-
-        try {
-            mUser.setUserId(response.getString(AuthUtil.USERID_KEY));
-            mUser.setAccessToken(response.getString(AuthUtil.ACCESS_TOKEN_KEY));
-        } catch(JSONException error){
+        if (!response.optString(AuthUtil.USERID_KEY).isEmpty() && !response.optString(AuthUtil.ACCESS_TOKEN_KEY).isEmpty()) {
+            mListener.onSuccess(mUser, response.optString(AuthUtil.USERID_KEY), response.optString(AuthUtil.ACCESS_TOKEN_KEY));
+        } else {
             mListener.onFailure(mUser, AuthException.defaultException());
-            return;
         }
-
-        mUser.setStatus(User.Status.AUTHORIZED);
-        mListener.onSuccess(mUser, mUser.getUserId(), mUser.getAccessToken());
     }
 
-    public void onError(AuthException error){
+    public void onError(AuthException error) {
         mListener.onFailure(mUser, error);
     }
-
 }

--- a/Simperium/src/main/java/com/simperium/client/AuthResponseListener.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthResponseListener.java
@@ -4,6 +4,6 @@ package com.simperium.client;
  * For use with Simperium.createUser and Simperium.authorizeUser
  */
 public interface AuthResponseListener {
-    public void onSuccess(User user);
+    public void onSuccess(User user, String userId, String token);
     public void onFailure(User user, AuthException error);
 }

--- a/Simperium/src/main/java/com/simperium/client/User.java
+++ b/Simperium/src/main/java/com/simperium/client/User.java
@@ -115,7 +115,7 @@ public class User {
         return userId;
     }
 
-    protected void setUserId(String userId){
+    public void setUserId(String userId){
         this.userId = userId;
     }
 

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
     <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
+    <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simperium account.</string>
     <string name="simperium_dialog_progress_logging_in">Logging in&#8230;</string>

--- a/Simperium/src/support/java/com/simperium/test/MockAuthResponseListener.java
+++ b/Simperium/src/support/java/com/simperium/test/MockAuthResponseListener.java
@@ -5,14 +5,12 @@ import com.simperium.client.AuthResponseListener;
 import com.simperium.client.User;
 
 public class MockAuthResponseListener implements AuthResponseListener {
-
+    public AuthException exception;
+    public User user;
     public boolean success = false, failure = false;
 
-    public User user;
-    public AuthException exception;
-
     @Override
-    public void onSuccess(User user){
+    public void onSuccess(User user, String userId, String token){
         success = true;
         this.user = user;
     }
@@ -23,5 +21,4 @@ public class MockAuthResponseListener implements AuthResponseListener {
         this.user = user;
         this.exception = exception;
     }
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.7'
+    '0.9.8'
 }


### PR DESCRIPTION
### Fix
Update the password policy so that users are not forced to reset their password when it doesn't meet the requirements below until a login is successful.
- Password cannot match username
- Minimum of 8 characters
- No new lines
- No tabs

### Test
These changes are best tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.  In order to test the login password length updates, change your Simplenote password to more than four and less than eight characters.  In the Simplenote app, follow the steps below.

0. Clear app data.
1. Tap ***Log In*** button.
2. Tap ***Log In with Email*** button.
3. Enter email address in ***Email*** field.
4. Notice ***Log In*** button is disabled.
5. Enter incorrect password of more than four and less than eight characters in ***Password*** field.
6. Notice ***Log In*** button is enabled after four characters are input.
7. Tap ***Log In*** button.
8. Notice ***Error*** dialog without password requirements is shown.
9. Tap ***OK*** button in dialog.
10. Enter correct password of more than four and less than eight characters in ***Password*** field.
11. Notice ***Log In*** button is enabled after four characters are input.
12. Tap ***Log In*** button.
13. Notice ***Error*** dialog with password requirements is shown.
14. Tap ***Reset*** button in dialog.
15. Notice external browser is opened showing the https://app.simplenote.com/forgot/ page.

### Review
Only one developer is required to review these changes, but anyone can perform the review.