### PR TITLE
Revert Websocket Threading

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
+++ b/Simperium/src/main/java/com/simperium/android/AsyncWebSocketProvider.java
@@ -1,6 +1,8 @@
 package com.simperium.android;
 
 import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 
 import com.koushikdutta.async.callback.CompletedCallback;
 import com.koushikdutta.async.http.AsyncHttpClient;
@@ -15,6 +17,7 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
     public static final String TAG = "Simperium.AsyncWebSocketProvider";
 
     private final AsyncHttpClient mAsyncClient;
+    private final Handler mHandler;
     private final String mAppId;
     private final String mSessionId;
 
@@ -22,6 +25,7 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
         mAppId = appId;
         mAsyncClient = asyncClient;
         mSessionId = sessionId;
+        mHandler = new Handler(Looper.getMainLooper());
     }
 
     @Override
@@ -47,12 +51,22 @@ class AsyncWebSocketProvider implements WebSocketManager.ConnectionProvider {
                 final WebSocketManager.Connection connection = new WebSocketManager.Connection() {
                     @Override
                     public void close() {
-                        webSocket.close();
+                        mHandler.post(new Runnable() {
+                                @Override
+                            public void run() {
+                                webSocket.close();
+                            }
+                        });
                     }
 
                     @Override
                     public void send(final String message) {
-                        webSocket.send(message);
+                        mHandler.post(new Runnable() {
+                            @Override
+                            public void run() {
+                                webSocket.send(message);
+                            }
+                        });
                     }
                 };
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.8'
+    '0.9.9'
 }


### PR DESCRIPTION
### Fix
Updates made in https://github.com/Simperium/simperium-android/pull/217 to avoid ANR (i.e. app-not-responding) reports due to the `AsyncWebSocketProvider` class are potentially causing data loss.  These changes revert the `AsyncWebSocketProvider` class updates by adding the main looper usage to avoid the possible data loss.

### Test
Simperium does not have a stand-alone application so there is nothing to run directly on a device or emulator other than tests. The following commands can be run from the project's root directory while a device or emulator is connected and ensure the tests pass.

```
./gradlew connectedCheck
./gradlew cAT
```
These changes can also be smoke tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.

### Review
Only one developer is required to review these changes, but anyone can perform the review.