### PR TITLE
Add Clear Password

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -318,6 +318,12 @@ public class CredentialsActivity extends AppCompatActivity {
         outState.putString(STATE_PASSWORD, getEditTextString(mInputPassword));
     }
 
+    private void clearPassword() {
+        if (mInputPassword.getEditText() != null) {
+            mInputPassword.getEditText().getText().clear();
+        }
+    }
+
     private String getEditTextString(@NonNull TextInputLayout inputLayout) {
         return inputLayout.getEditText() != null ? inputLayout.getEditText().getText().toString() : "";
     }
@@ -417,6 +423,7 @@ public class CredentialsActivity extends AppCompatActivity {
                             Uri uri = Uri.parse(getString(R.string.simperium_dialog_button_reset_url, URLEncoder.encode(getEditTextString(mInputEmail), UTF_8)));
                             Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                             startActivity(intent);
+                            clearPassword();
                         } catch (UnsupportedEncodingException e) {
                             throw new RuntimeException("Unable to parse URL", e);
                         }

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.10'
+    '0.9.11'
 }


### PR DESCRIPTION
### Fix
Add the `clearPassword` method to clear the password field in `CredentialsActivity` when the ***Reset*** button is tapped in the **_Error_** dialog after entering the correct password for the account that does not meet the new password policy requirements.

### Test
These changes are best tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.

0. Clear app data.
1. Tap ***Log In*** button.
2. Tap ***Log In with Email*** button.
3. Enter email address in ***Email*** field.
4. Notice ***Log In*** button is disabled.
5. Enter incorrect password of more than four and less than eight characters in ***Password*** field.
6. Notice ***Log In*** button is enabled after four characters are entered.
7. Tap ***Log In*** button.
8. Notice ***Error*** dialog without password requirements is shown.
9. Tap ***OK*** button in dialog.
10. Enter correct password of more than four and less than eight characters in ***Password*** field.
11. Notice ***Log In*** button is enabled after four characters are input.
12. Tap ***Log In*** button.
13. Notice ***Error*** dialog with password requirements is shown.
14. Tap ***Cancel*** button in dialog.
15. Notice ***Password*** field is not cleared.
16. Tap ***Log In*** button.
17. Notice ***Error*** dialog with password requirements is shown.
18. Tap ***Rest*** button in dialog.
19. Notice ***Password*** field is cleared.

### Review
Only one developer is required to review these changes, but anyone can perform the review.