### PR TITLE
Update Password Policy

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -44,7 +44,7 @@ import static com.simperium.android.AuthenticationActivity.EXTRA_IS_LOGIN;
 import static org.apache.http.protocol.HTTP.UTF_8;
 
 public class CredentialsActivity extends AppCompatActivity {
-    private static final Pattern PATTERN_NEWLINES_TABS = Pattern.compile("[\n\t]");
+    private static final Pattern PATTERN_NEWLINES_RETURNS_TABS = Pattern.compile("[\n\r\t]");
     private static final Pattern PATTERN_WHITESPACE = Pattern.compile("(\\s)");
     private static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
     private static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
@@ -338,7 +338,7 @@ public class CredentialsActivity extends AppCompatActivity {
     // - Does not have new lines or tabs (PATTERN_NEWLINES_TABS)
     // - Does not match email address
     private boolean isValidPassword(String email, String password) {
-        return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_TABS.matcher(password).find() && !email.contentEquals(password);
+        return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_RETURNS_TABS.matcher(password).find() && !email.contentEquals(password);
     }
 
     private boolean isValidPasswordLength(boolean isLogin) {

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="simperium_dialog_message_login">Could not log in with the provided email address and password.</string>
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
-    <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
+    <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No returns\n- No tabs</string>
     <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simperium account.</string>

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.10'
+    '0.9.12'
 }


### PR DESCRIPTION
### Fix
Update the password policy requirements to the following:
- Password cannot match username
- Minimum of 8 characters
- No new lines
- No returns
- No tabs

### Test
These changes are best tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.  In order to test the login password length updates, change your Simplenote password to more than four and less than eight characters.  In the Simplenote app, follow the steps below.

0. Clear app data.
1. Tap ***Sign Up*** button.
2. Enter email address in ***Email*** field.
3. Notice ***Sign Up*** button is disabled.
4. Enter email address, new lines, or tabs in ***Password*** field.
5. Notice ***Sign Up*** button is enabled after eight characters are input.
6. Tap ***Sign Up*** button.
7. Notice ***Error*** dialog with password requirements is shown.
8. Tap ***OK*** button in dialog.
9. Tap back arrow in top app bar.
10. Tap ***Log In*** button.
11. Tap ***Log In with Email*** button.
12. Enter email address in ***Email*** field.
13. Notice ***Log In*** button is disabled.
14. Enter password of more than four and less than eight characters in ***Password*** field.
15. Notice ***Log In*** button is enabled after four characters are input.
16. Tap ***Log In*** button.
17. Notice ***Error*** dialog with password requirements is shown.
18. Tap ***Reset*** button in dialog.
19. Notice external browser is opened showing the https://app.simplenote.com/forgot/ page.

### Review
Only one developer is required to review these changes, but anyone can perform the review.