### PR TITLE
Add heartbeat listener interface for detecting server communication status

### DIFF
--- a/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
+++ b/Simperium/src/androidTestSupport/java/com/simperium/ChannelTest.java
@@ -57,8 +57,7 @@ public class ChannelTest extends BaseSimperiumTest {
         mBucketExecutor.clear();
         mBucketExecutor.play();
 
-        mBucket = MockBucket.buildBucket(mBucketExecutor, new Note.Schema(), new ChannelProvider(){
-
+        mBucket = MockBucket.buildBucket(mBucketExecutor, new Note.Schema(), new ChannelProvider() {
             @Override
             public Bucket.Channel buildChannel(Bucket bucket){
                 mChannelSerializer = new MockChannelSerializer();
@@ -76,6 +75,9 @@ public class ChannelTest extends BaseSimperiumTest {
                 return 0;
             }
 
+            @Override
+            public void addHeartbeatListener(HeartbeatListener listener) {
+            }
         });
 
         mBucket.getUser().setStatusChangeListener(new User.StatusChangeListener(){

--- a/Simperium/src/main/java/com/simperium/Simperium.java
+++ b/Simperium/src/main/java/com/simperium/Simperium.java
@@ -77,8 +77,12 @@ public class Simperium implements User.StatusChangeListener {
     public static Simperium getInstance() throws SimperiumNotInitializedException{
     	if(null == simperiumClient)
     		throw new SimperiumNotInitializedException("You must create an instance of Simperium before call this method.");
-    	
+
     	return simperiumClient;
+    }
+
+    public void addHeartbeatListener(ChannelProvider.HeartbeatListener listener) {
+        mChannelProvider.addHeartbeatListener(listener);
     }
 
     private void loadUser(){

--- a/Simperium/src/main/java/com/simperium/client/ChannelProvider.java
+++ b/Simperium/src/main/java/com/simperium/client/ChannelProvider.java
@@ -20,4 +20,9 @@ public interface ChannelProvider {
     public int getLogLevel();
 
 
+    public interface HeartbeatListener {
+        public void onBeat();
+    }
+
+    public void addHeartbeatListener(HeartbeatListener listener);
 }

--- a/Simperium/src/support/java/com/simperium/test/MockChannelProvider.java
+++ b/Simperium/src/support/java/com/simperium/test/MockChannelProvider.java
@@ -26,6 +26,10 @@ public class MockChannelProvider implements ChannelProvider {
         return ChannelProvider.LOG_DISABLED;
     }
 
+    @Override
+    public void addHeartbeatListener(HeartbeatListener listener) {
+    }
+
     public String getLastLog() {
         if (logs.size() > 0) {
             return logs.get(logs.size()-1);


### PR DESCRIPTION
Previously we haven't offered any way to determine if the connection with the
Simperium server is up or not. With this change we're exposing a new listener
that a client application can use to be pinged whenever we get a heartbeat
signal from the server, indicating that a connection is active.

This is demo code and I don't expect it to look right but I was mainly trying to
determine if this is feasible and get some feedback on where it should belong.

Connect in a client library like this…
```java
mSimperium.addHeartbeatListener(new ChannelProvider.HeartbeatListener() {
    @Override
    public void onBeat() {
        // update the last-known communication time with the server
    }
});
```

and then we can create some timer to check if it's been longer than some
threshold number of seconds since we last heard from the server. we can
update the UI or an app flag based on that.