### PR TITLE
Update Password Policy

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -369,7 +369,7 @@ public class CredentialsActivity extends AppCompatActivity {
 
     // Password is valid if:
     // - Meets minimum length requirement based on login (PASSWORD_LENGTH_LOGIN) and signup (PASSWORD_LENGTH_MINIMUM)
-    // - Does not have new lines or tabs (PATTERN_NEWLINES_TABS)
+    // - Does not have new lines, returns, or tabs (PATTERN_NEWLINES_RETURNS_TABS)
     // - Does not match email address
     private boolean isValidPassword(String email, String password) {
         return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_RETURNS_TABS.matcher(password).find() && !email.contentEquals(password);
@@ -488,7 +488,7 @@ public class CredentialsActivity extends AppCompatActivity {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 
-        if (isValidPasswordLogin(password)) {
+        if (isValidPasswordLogin()) {
             mProgressDialogFragment = ProgressDialogFragment.newInstance(getString(R.string.simperium_dialog_progress_logging_in));
             mProgressDialogFragment.setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Simperium);
             mProgressDialogFragment.show(getSupportFragmentManager(), ProgressDialogFragment.TAG);

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -48,7 +48,6 @@ import static org.apache.http.protocol.HTTP.UTF_8;
 
 public class CredentialsActivity extends AppCompatActivity {
     private static final Pattern PATTERN_NEWLINES_RETURNS_TABS = Pattern.compile("[\n\r\t]");
-    private static final Pattern PATTERN_WHITESPACE = Pattern.compile("(\\s)");
     private static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
     private static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
     private static final String STATE_EMAIL = "STATE_EMAIL";
@@ -384,8 +383,8 @@ public class CredentialsActivity extends AppCompatActivity {
             );
     }
 
-    private boolean isValidPasswordLogin(String password) {
-        return isValidPasswordLength(mIsLogin) && !PATTERN_WHITESPACE.matcher(password).find();
+    private boolean isValidPasswordLogin() {
+        return isValidPasswordLength(mIsLogin);
     }
 
     private void setButtonState() {

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -383,6 +383,8 @@ public class CredentialsActivity extends AppCompatActivity {
             );
     }
 
+    // Use old password requirements for login validation:
+    // - Meets minimum length requirement (PASSWORD_LENGTH_LOGIN)
     private boolean isValidPasswordLogin() {
         return isValidPasswordLength(mIsLogin);
     }

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="simperium_dialog_message_login_reset">Your password is insecure and must be reset.  The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No tabs</string>
     <string name="simperium_dialog_message_network">There is no network available.  Please, connect to a network and try again.</string>
     <string name="simperium_dialog_message_password">The password requirements are:\n\n- Password cannot match username\n- Minimum of %1$d characters\n- No new lines\n- No returns\n- No tabs</string>
-    <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters excluding new lines, spaces, and tabs.</string>
+    <string name="simperium_dialog_message_password_login">Passwords must be a minimum of %1$d characters.</string>
     <string name="simperium_dialog_message_signup">Could not sign up with the provided email address and password.</string>
     <string name="simperium_dialog_message_signup_existing">The email address you entered is already associated with a Simperium account.</string>
     <string name="simperium_dialog_progress_logging_in">Logging in&#8230;</string>

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.13'
+    '0.9.14'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.14'
+    '0.9.14-rc1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.9.14-rc1'
+    '0.9.14'
 }


### PR DESCRIPTION
### Fix
Update the password validation for login to meet the old password requirements.  Since we force users to reset their password if it doesn't meet the new password requirements only after a successful login first, we need to allow login with the old password requirements initially.  These changes specifically remove the restriction for logins to exclude whitespace characters from the password.

### Test
These changes are best tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository.  Contact me for details.  In order to test this pull request specifically, change your Simplenote password to include one or more spaces.  In the Simplenote app, follow the steps below.

#### Note
If you are using Android Studio 4.0.0 or later, you'll have to comment out the [`plugin` statement](https://github.com/Simperium/simperium-android/blob/098bece0f6fe0f41bd13359b08f28482faf5a76d/Simperium/build.gradle#L2) and [`publish` block](https://github.com/Simperium/simperium-android/blob/098bece0f6fe0f41bd13359b08f28482faf5a76d/Simperium/build.gradle#L110-L122) in the `simperium-android/Simperium/build.gradle` file.  Otherwise, you won't be able to build the app.  The plugin for Bintray releases is not supported for Gradle 6.0.0 or later and Android Studio 4.0.0 requires Gradle 6.1.1.

0. Clear app data.
1. Tap ***Log In*** button.
2. Tap ***Log In with Email*** button.
3. Enter email address in ***Email*** field.
4. Notice ***Log In*** button is disabled.
5. Enter password containing one or more spaces in ***Password*** field.
6. Notice ***Log In*** button is enabled after four characters are input.
7. Tap ***Log In*** button.
8. Notice app is logged in.

### Review
Only one developer is required to review these changes, but anyone can perform the review.