### PR TITLE
Add compromised password response handling

### DIFF
--- a/Simperium/build.gradle
+++ b/Simperium/build.gradle
@@ -24,12 +24,11 @@ repositories {
 }
 
 android {
-    buildToolsVersion "28.0.3"
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionName project.version
 
         // Calculating PIN for certificate: OU=Domain Control Validated, CN=*.simperium.com

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -47,24 +47,24 @@ import static com.simperium.android.AuthenticationActivity.EXTRA_IS_LOGIN;
 import static org.apache.http.protocol.HTTP.UTF_8;
 
 public class CredentialsActivity extends AppCompatActivity {
-    protected static final Pattern PATTERN_NEWLINES_RETURNS_TABS = Pattern.compile("[\n\r\t]");
-    protected static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
-    protected static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
-    protected static final String STATE_EMAIL = "STATE_EMAIL";
-    protected static final String STATE_PASSWORD = "STATE_PASSWORD";
-    protected static final int DELAY_AUTOMATE_LOGIN = 600;
-    protected static final int PASSWORD_LENGTH_LOGIN = 4;
-    protected static final int PASSWORD_LENGTH_MINIMUM = 8;
+    private static final Pattern PATTERN_NEWLINES_RETURNS_TABS = Pattern.compile("[\n\r\t]");
+    private static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
+    private static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
+    private static final String STATE_EMAIL = "STATE_EMAIL";
+    private static final String STATE_PASSWORD = "STATE_PASSWORD";
+    private static final int DELAY_AUTOMATE_LOGIN = 600;
+    private static final int PASSWORD_LENGTH_LOGIN = 4;
+    private static final int PASSWORD_LENGTH_MINIMUM = 8;
 
     protected ProgressDialogFragment mProgressDialogFragment;
 
-    protected AppCompatButton mButton;
-    protected Simperium mSimperium;
-    protected TextInputLayout mInputEmail;
-    protected TextInputLayout mInputPassword;
-    protected boolean mIsLogin;
+    private AppCompatButton mButton;
+    private Simperium mSimperium;
+    private TextInputLayout mInputEmail;
+    private TextInputLayout mInputPassword;
+    private boolean mIsLogin;
 
-    protected AuthResponseListener mAuthListener = new AuthResponseListener() {
+    private AuthResponseListener mAuthListener = new AuthResponseListener() {
         @Override
         public void onFailure(final User user, final AuthException error) {
             runOnUiThread(
@@ -326,13 +326,13 @@ public class CredentialsActivity extends AppCompatActivity {
         outState.putString(STATE_PASSWORD, getEditTextString(mInputPassword));
     }
 
-    protected void clearPassword() {
+    private void clearPassword() {
         if (mInputPassword.getEditText() != null) {
             mInputPassword.getEditText().getText().clear();
         }
     }
 
-    protected void copyToClipboard(String url) {
+    private void copyToClipboard(String url) {
         Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
 
         try {
@@ -350,23 +350,23 @@ public class CredentialsActivity extends AppCompatActivity {
         }
     }
 
-    protected String getEditTextString(@NonNull TextInputLayout inputLayout) {
+    private String getEditTextString(@NonNull TextInputLayout inputLayout) {
         return inputLayout.getEditText() != null ? inputLayout.getEditText().getText().toString() : "";
     }
 
-    protected void hideDialogProgress() {
+    private void hideDialogProgress() {
         if (mProgressDialogFragment != null && !mProgressDialogFragment.isHidden()) {
             mProgressDialogFragment.dismiss();
             mProgressDialogFragment = null;
         }
     }
 
-    protected boolean isBrowserInstalled() {
+    private boolean isBrowserInstalled() {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.simperium_url)));
         return (intent.resolveActivity(getPackageManager()) != null);
     }
 
-    protected boolean isValidEmail(String text) {
+    private boolean isValidEmail(String text) {
         return Patterns.EMAIL_ADDRESS.matcher(text).matches();
     }
 
@@ -374,11 +374,11 @@ public class CredentialsActivity extends AppCompatActivity {
     // - Meets minimum length requirement based on login (PASSWORD_LENGTH_LOGIN) and signup (PASSWORD_LENGTH_MINIMUM)
     // - Does not have new lines, returns, or tabs (PATTERN_NEWLINES_RETURNS_TABS)
     // - Does not match email address
-    protected boolean isValidPassword(String email, String password) {
+    private boolean isValidPassword(String email, String password) {
         return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_RETURNS_TABS.matcher(password).find() && !email.contentEquals(password);
     }
 
-    protected boolean isValidPasswordLength(boolean isLogin) {
+    private boolean isValidPasswordLength(boolean isLogin) {
         return mInputPassword.getEditText() != null &&
             (isLogin ?
                 getEditTextString(mInputPassword).length() >= PASSWORD_LENGTH_LOGIN :
@@ -388,11 +388,11 @@ public class CredentialsActivity extends AppCompatActivity {
 
     // Use old password requirements for login validation:
     // - Meets minimum length requirement (PASSWORD_LENGTH_LOGIN)
-    protected boolean isValidPasswordLogin() {
+    private boolean isValidPasswordLogin() {
         return isValidPasswordLength(mIsLogin);
     }
 
-    protected void setButtonState() {
+    private void setButtonState() {
         mButton.setEnabled(
             mInputEmail.getEditText() != null &&
             mInputPassword.getEditText() != null &&
@@ -401,13 +401,13 @@ public class CredentialsActivity extends AppCompatActivity {
         );
     }
 
-    protected void setEditTextString(@NonNull TextInputLayout inputLayout, String text) {
+    private void setEditTextString(@NonNull TextInputLayout inputLayout, String text) {
         if (inputLayout.getEditText() != null ) {
             inputLayout.getEditText().setText(text);
         }
     }
 
-    protected void showDialogError(String message) {
+    private void showDialogError(String message) {
         hideDialogProgress();
         Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
@@ -417,7 +417,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    protected void showDialogErrorExistingAccount() {
+    private void showDialogErrorExistingAccount() {
         hideDialogProgress();
         Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
@@ -441,7 +441,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    protected void showDialogErrorLoginReset() {
+    private void showDialogErrorLoginReset() {
         hideDialogProgress();
         final Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
@@ -470,7 +470,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    protected void showDialogErrorBrowser(final String url) {
+    private void showDialogErrorBrowser(final String url) {
         final Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
             .setTitle(R.string.simperium_dialog_title_error_browser)
@@ -487,7 +487,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    protected void showCompromisedPasswordDialog() {
+    private void showCompromisedPasswordDialog() {
         hideDialogProgress();
         final Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
@@ -516,7 +516,7 @@ public class CredentialsActivity extends AppCompatActivity {
                 .show();
     }
 
-    protected void startLogin() {
+    private void startLogin() {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 
@@ -530,7 +530,7 @@ public class CredentialsActivity extends AppCompatActivity {
         }
     }
 
-    protected void startSignup() {
+    private void startSignup() {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -75,6 +75,9 @@ public class CredentialsActivity extends AppCompatActivity {
                             case EXISTING_ACCOUNT:
                                 showDialogErrorExistingAccount();
                                 break;
+                            case COMPROMISED_PASSWORD:
+                                showCompromisedPasswordDialog();
+                                break;
                             case INVALID_ACCOUNT:
                             default:
                                 showDialogError(getString(
@@ -482,6 +485,35 @@ public class CredentialsActivity extends AppCompatActivity {
             )
             .setPositiveButton(android.R.string.ok, null)
             .show();
+    }
+
+    protected void showCompromisedPasswordDialog() {
+        hideDialogProgress();
+        final Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
+        new AlertDialog.Builder(context)
+                .setTitle(R.string.simperium_compromised_password)
+                .setMessage(R.string.simperium_compromised_password_message)
+                .setNegativeButton(R.string.simperium_not_now, null)
+                .setPositiveButton(R.string.simperium_change_password,
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                try {
+                                    String url = getString(com.simperium.R.string.simperium_dialog_button_reset_url, URLEncoder.encode(getEditTextString(mInputEmail), UTF_8));
+
+                                    if (isBrowserInstalled()) {
+                                        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                                        clearPassword();
+                                    } else {
+                                        showDialogErrorBrowser(url);
+                                    }
+                                } catch (UnsupportedEncodingException e) {
+                                    throw new RuntimeException("Unable to parse URL", e);
+                                }
+                            }
+                        }
+                )
+                .show();
     }
 
     protected void startLogin() {

--- a/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/CredentialsActivity.java
@@ -47,24 +47,24 @@ import static com.simperium.android.AuthenticationActivity.EXTRA_IS_LOGIN;
 import static org.apache.http.protocol.HTTP.UTF_8;
 
 public class CredentialsActivity extends AppCompatActivity {
-    private static final Pattern PATTERN_NEWLINES_RETURNS_TABS = Pattern.compile("[\n\r\t]");
-    private static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
-    private static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
-    private static final String STATE_EMAIL = "STATE_EMAIL";
-    private static final String STATE_PASSWORD = "STATE_PASSWORD";
-    private static final int DELAY_AUTOMATE_LOGIN = 600;
-    private static final int PASSWORD_LENGTH_LOGIN = 4;
-    private static final int PASSWORD_LENGTH_MINIMUM = 8;
+    protected static final Pattern PATTERN_NEWLINES_RETURNS_TABS = Pattern.compile("[\n\r\t]");
+    protected static final String EXTRA_AUTOMATE_LOGIN = "EXTRA_AUTOMATE_LOGIN";
+    protected static final String EXTRA_PASSWORD = "EXTRA_PASSWORD";
+    protected static final String STATE_EMAIL = "STATE_EMAIL";
+    protected static final String STATE_PASSWORD = "STATE_PASSWORD";
+    protected static final int DELAY_AUTOMATE_LOGIN = 600;
+    protected static final int PASSWORD_LENGTH_LOGIN = 4;
+    protected static final int PASSWORD_LENGTH_MINIMUM = 8;
 
     protected ProgressDialogFragment mProgressDialogFragment;
 
-    private AppCompatButton mButton;
-    private Simperium mSimperium;
-    private TextInputLayout mInputEmail;
-    private TextInputLayout mInputPassword;
-    private boolean mIsLogin;
+    protected AppCompatButton mButton;
+    protected Simperium mSimperium;
+    protected TextInputLayout mInputEmail;
+    protected TextInputLayout mInputPassword;
+    protected boolean mIsLogin;
 
-    private AuthResponseListener mAuthListener = new AuthResponseListener() {
+    protected AuthResponseListener mAuthListener = new AuthResponseListener() {
         @Override
         public void onFailure(final User user, final AuthException error) {
             runOnUiThread(
@@ -323,13 +323,13 @@ public class CredentialsActivity extends AppCompatActivity {
         outState.putString(STATE_PASSWORD, getEditTextString(mInputPassword));
     }
 
-    private void clearPassword() {
+    protected void clearPassword() {
         if (mInputPassword.getEditText() != null) {
             mInputPassword.getEditText().getText().clear();
         }
     }
 
-    private void copyToClipboard(String url) {
+    protected void copyToClipboard(String url) {
         Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
 
         try {
@@ -347,23 +347,23 @@ public class CredentialsActivity extends AppCompatActivity {
         }
     }
 
-    private String getEditTextString(@NonNull TextInputLayout inputLayout) {
+    protected String getEditTextString(@NonNull TextInputLayout inputLayout) {
         return inputLayout.getEditText() != null ? inputLayout.getEditText().getText().toString() : "";
     }
 
-    private void hideDialogProgress() {
+    protected void hideDialogProgress() {
         if (mProgressDialogFragment != null && !mProgressDialogFragment.isHidden()) {
             mProgressDialogFragment.dismiss();
             mProgressDialogFragment = null;
         }
     }
 
-    private boolean isBrowserInstalled() {
+    protected boolean isBrowserInstalled() {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.simperium_url)));
         return (intent.resolveActivity(getPackageManager()) != null);
     }
 
-    private boolean isValidEmail(String text) {
+    protected boolean isValidEmail(String text) {
         return Patterns.EMAIL_ADDRESS.matcher(text).matches();
     }
 
@@ -371,11 +371,11 @@ public class CredentialsActivity extends AppCompatActivity {
     // - Meets minimum length requirement based on login (PASSWORD_LENGTH_LOGIN) and signup (PASSWORD_LENGTH_MINIMUM)
     // - Does not have new lines, returns, or tabs (PATTERN_NEWLINES_RETURNS_TABS)
     // - Does not match email address
-    private boolean isValidPassword(String email, String password) {
+    protected boolean isValidPassword(String email, String password) {
         return isValidPasswordLength(mIsLogin) && !PATTERN_NEWLINES_RETURNS_TABS.matcher(password).find() && !email.contentEquals(password);
     }
 
-    private boolean isValidPasswordLength(boolean isLogin) {
+    protected boolean isValidPasswordLength(boolean isLogin) {
         return mInputPassword.getEditText() != null &&
             (isLogin ?
                 getEditTextString(mInputPassword).length() >= PASSWORD_LENGTH_LOGIN :
@@ -385,11 +385,11 @@ public class CredentialsActivity extends AppCompatActivity {
 
     // Use old password requirements for login validation:
     // - Meets minimum length requirement (PASSWORD_LENGTH_LOGIN)
-    private boolean isValidPasswordLogin() {
+    protected boolean isValidPasswordLogin() {
         return isValidPasswordLength(mIsLogin);
     }
 
-    private void setButtonState() {
+    protected void setButtonState() {
         mButton.setEnabled(
             mInputEmail.getEditText() != null &&
             mInputPassword.getEditText() != null &&
@@ -398,13 +398,13 @@ public class CredentialsActivity extends AppCompatActivity {
         );
     }
 
-    private void setEditTextString(@NonNull TextInputLayout inputLayout, String text) {
+    protected void setEditTextString(@NonNull TextInputLayout inputLayout, String text) {
         if (inputLayout.getEditText() != null ) {
             inputLayout.getEditText().setText(text);
         }
     }
 
-    private void showDialogError(String message) {
+    protected void showDialogError(String message) {
         hideDialogProgress();
         Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
@@ -414,7 +414,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    private void showDialogErrorExistingAccount() {
+    protected void showDialogErrorExistingAccount() {
         hideDialogProgress();
         Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
@@ -438,7 +438,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    private void showDialogErrorLoginReset() {
+    protected void showDialogErrorLoginReset() {
         hideDialogProgress();
         final Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
@@ -467,7 +467,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    private void showDialogErrorBrowser(final String url) {
+    protected void showDialogErrorBrowser(final String url) {
         final Context context = new ContextThemeWrapper(CredentialsActivity.this, getTheme());
         new AlertDialog.Builder(context)
             .setTitle(R.string.simperium_dialog_title_error_browser)
@@ -484,7 +484,7 @@ public class CredentialsActivity extends AppCompatActivity {
             .show();
     }
 
-    private void startLogin() {
+    protected void startLogin() {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 
@@ -498,7 +498,7 @@ public class CredentialsActivity extends AppCompatActivity {
         }
     }
 
-    private void startSignup() {
+    protected void startSignup() {
         final String email = getEditTextString(mInputEmail);
         final String password = getEditTextString(mInputPassword);
 

--- a/Simperium/src/main/java/com/simperium/client/AuthException.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthException.java
@@ -9,7 +9,7 @@ public class AuthException extends SimperiumException {
     static public final String GENERIC_FAILURE_MESSAGE = "Invalid username or password";
     static public final String EXISTING_USER_FAILURE_MESSAGE = "Account already exists";
     static public final String COMPROMISED_PASSWORD_MESSAGE = "Password has been compromised";
-    static public final String INVALID_LOGIN_BODY = "invalid login";
+    static public final String COMPROMISED_PASSWORD_BODY = "compromised password";
 
     static public final int ERROR_STATUS_CODE = -1;
 
@@ -44,7 +44,7 @@ public class AuthException extends SimperiumException {
             case 401:
                 // Code 401 can be obtain because credentials are wrong or the user's password has been compromised
                 // To differentiate both responses, we check the response's body
-                if (cause != null && !Objects.equals(cause.getMessage(), INVALID_LOGIN_BODY)) {
+                if (cause != null && Objects.equals(cause.getMessage(), COMPROMISED_PASSWORD_BODY)) {
                     return new AuthException(FailureType.COMPROMISED_PASSWORD, COMPROMISED_PASSWORD_MESSAGE, cause);
                 }
             default:

--- a/Simperium/src/main/java/com/simperium/client/AuthException.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthException.java
@@ -44,7 +44,8 @@ public class AuthException extends SimperiumException {
             case 401:
                 // Code 401 can be obtain because credentials are wrong or the user's password has been compromised
                 // To differentiate both responses, we check the response's body
-                if (cause != null && Objects.equals(cause.getMessage(), COMPROMISED_PASSWORD_BODY)) {
+                String message = cause != null && cause.getMessage() != null ? cause.getMessage().toLowerCase() : "";
+                if (Objects.equals(message, COMPROMISED_PASSWORD_BODY)) {
                     return new AuthException(FailureType.COMPROMISED_PASSWORD, COMPROMISED_PASSWORD_MESSAGE, cause);
                 }
             default:

--- a/Simperium/src/main/java/com/simperium/client/AuthException.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthException.java
@@ -9,8 +9,6 @@ public class AuthException extends SimperiumException {
     static public final String COMPROMISED_PASSWORD_MESSAGE = "Password has been compromised";
 
     static public final int ERROR_STATUS_CODE = -1;
-    static public final int INVALID_ACCOUNT_CODE = 0x0;
-    static public final int EXISTING_ACCOUNT_CODE = 0x1;
 
     public final FailureType failureType;
 

--- a/Simperium/src/main/java/com/simperium/client/AuthException.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthException.java
@@ -44,9 +44,7 @@ public class AuthException extends SimperiumException {
             case 401:
                 // Code 401 can be obtain because credentials are wrong or the user's password has been compromised
                 // To differentiate both responses, we check the response's body
-                if (cause != null && Objects.equals(cause.getMessage(), INVALID_LOGIN_BODY)) {
-                    return new AuthException(FailureType.INVALID_ACCOUNT, GENERIC_FAILURE_MESSAGE, cause);
-                } else {
+                if (cause != null && !Objects.equals(cause.getMessage(), INVALID_LOGIN_BODY)) {
                     return new AuthException(FailureType.COMPROMISED_PASSWORD, COMPROMISED_PASSWORD_MESSAGE, cause);
                 }
             default:

--- a/Simperium/src/main/java/com/simperium/client/AuthException.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthException.java
@@ -6,6 +6,7 @@ public class AuthException extends SimperiumException {
 
     static public final String GENERIC_FAILURE_MESSAGE = "Invalid username or password";
     static public final String EXISTING_USER_FAILURE_MESSAGE = "Account already exists";
+    static public final String COMPROMISED_PASSWORD_MESSAGE = "Password has been compromised";
 
     static public final int ERROR_STATUS_CODE = -1;
     static public final int INVALID_ACCOUNT_CODE = 0x0;
@@ -14,7 +15,7 @@ public class AuthException extends SimperiumException {
     public final FailureType failureType;
 
     public enum FailureType {
-        INVALID_ACCOUNT, EXISTING_ACCOUNT
+        INVALID_ACCOUNT, EXISTING_ACCOUNT, COMPROMISED_PASSWORD
     }
 
     public AuthException(FailureType code, String message){
@@ -39,6 +40,8 @@ public class AuthException extends SimperiumException {
         switch (statusCode) {
             case 409:
                 return new AuthException(FailureType.EXISTING_ACCOUNT, EXISTING_USER_FAILURE_MESSAGE, cause);
+            case 401:
+                return new AuthException(FailureType.COMPROMISED_PASSWORD, COMPROMISED_PASSWORD_MESSAGE, cause);
             default:
                 return new AuthException(FailureType.INVALID_ACCOUNT, GENERIC_FAILURE_MESSAGE, cause);
         }

--- a/Simperium/src/main/java/com/simperium/client/AuthException.java
+++ b/Simperium/src/main/java/com/simperium/client/AuthException.java
@@ -2,11 +2,14 @@ package com.simperium.client;
 
 import com.simperium.SimperiumException;
 
+import java.util.Objects;
+
 public class AuthException extends SimperiumException {
 
     static public final String GENERIC_FAILURE_MESSAGE = "Invalid username or password";
     static public final String EXISTING_USER_FAILURE_MESSAGE = "Account already exists";
     static public final String COMPROMISED_PASSWORD_MESSAGE = "Password has been compromised";
+    static public final String INVALID_LOGIN_BODY = "invalid login";
 
     static public final int ERROR_STATUS_CODE = -1;
 
@@ -39,7 +42,13 @@ public class AuthException extends SimperiumException {
             case 409:
                 return new AuthException(FailureType.EXISTING_ACCOUNT, EXISTING_USER_FAILURE_MESSAGE, cause);
             case 401:
-                return new AuthException(FailureType.COMPROMISED_PASSWORD, COMPROMISED_PASSWORD_MESSAGE, cause);
+                // Code 401 can be obtain because credentials are wrong or the user's password has been compromised
+                // To differentiate both responses, we check the response's body
+                if (cause != null && Objects.equals(cause.getMessage(), INVALID_LOGIN_BODY)) {
+                    return new AuthException(FailureType.INVALID_ACCOUNT, GENERIC_FAILURE_MESSAGE, cause);
+                } else {
+                    return new AuthException(FailureType.COMPROMISED_PASSWORD, COMPROMISED_PASSWORD_MESSAGE, cause);
+                }
             default:
                 return new AuthException(FailureType.INVALID_ACCOUNT, GENERIC_FAILURE_MESSAGE, cause);
         }

--- a/Simperium/src/main/res/values/strings.xml
+++ b/Simperium/src/main/res/values/strings.xml
@@ -34,7 +34,10 @@
     <string name="simperium_hint_email">Email</string>
     <string name="simperium_hint_password">Password</string>
     <string name="simperium_subtitle">App data, everywhere it\'s needed.</string>
+    <string name="simperium_compromised_password">Compromised Password</string>
+    <string name="simperium_compromised_password_message">This password has appeared in a data breach, which puts your account at high risk of compromise. It is recommended that you change your password immediately.</string>
+    <string name="simperium_not_now">Not Now</string>
+    <string name="simperium_change_password">Change Password</string>
     <string name="simperium_title">@string/app_name</string>
     <string name="simperium_url">https://simperium.com/</string>
-
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.11.0'
+    '0.10.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,5 +35,5 @@ def gitDescribe() {
 }
 
 def static gitVersion() {
-    '0.10.0'
+    '0.11.0'
 }


### PR DESCRIPTION
### Fix

We are adding a verification dialog in case the user's password has been compromised. This does not let the user login and provides a button that will take the user to reset their password. This fixes the issue https://github.com/Automattic/simplenote-android/issues/1439. Discussions about the behavior of the endpoint are in p2XLIi-28F-p2.

### Test
These changes are best tested on Simplenote by pointing your local Simplenote repository to your local Simperium repository. Follow the next steps:

1. Install simperium-android in maven local:
```
./gradlew clean publishToMavenLocal -Pversion=0.10.1
```
2. In simplenote app, add maven local to list of repositories in `Simplenote/gradle.build`:
```groovy
repositories {
    jcenter()
    maven { url "https://maven.google.com" }
    maven { url "https://s3.amazonaws.com/repo.commonsware.com" }
    mavenLocal()
}
```

3. Update simperium dependency to `0.10.1`.
4. Build and install the application.

In the Simplenote app, follow the steps below:

1. Tap ***Log In*** button.
2. Tap ***Log In with Email*** button.
3. Enter email address in ***Email*** field.
4. Notice ***Log In*** button is disabled.
5. Enter incorrect password of more than four and less than eight characters in ***Password*** field.
6. Notice ***Log In*** button is enabled after four characters are input.
7. Tap ***Log In*** button.
8. Notice ***Error*** dialog that shows invalid credentials.
9. Tap ***OK*** button in dialog.
10. Enter correct password of more than seven characters in ***Password*** field.
11. Notice ***Log In*** button is enabled after four characters are input.
12. Tap ***Log In*** button.
13. Notice app is successfully logged in.
14. Logout and know try a user with compromised password. If the backend implementation has not been implemented, go to the class `AuthException` and change `static public final String COMPROMISED_PASSWORD_BODY = "compromised password";` by `static public final String COMPROMISED_PASSWORD_BODY = "invalid login";` and publish to maven local again. 
14. Go to login and type the correct credentials of the account with a compromised password or invalid credentials if it has not been implemented.
15. Notice ***Error*** dialog that shows compromised password.

### Review
Only one developer is required to review these changes, but anyone can perform the review.