### PR TITLE
Check for SQLException when getting object from SQLite storage

### DIFF
--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -515,8 +515,11 @@ public class Bucket<T extends Syncable> {
             throw(new BucketObjectMissingException(String.format("Bucket %s does not have object %s", getName(), key)));
         }
 
-        // Check if there isn't an SQLException (e.g. SQLiteBlobTooBigException) to avoid propageting an unchecked
+        // Check if there isn't an SQLException (e.g. SQLiteBlobTooBigException) to avoid propagating an unchecked
         // exception.
+        // Note: this check should be at the storage level since at the Bucket level we don't know that we are dealing
+        // with a SQLite storage. However, at this point we have more information about what is happening, thus, it can
+        // be better reported.
         T object;
         try {
             object = mStorage.get(key);

--- a/Simperium/src/main/java/com/simperium/client/Bucket.java
+++ b/Simperium/src/main/java/com/simperium/client/Bucket.java
@@ -22,6 +22,7 @@ package com.simperium.client;
 
 import android.database.Cursor;
 import android.database.CursorWrapper;
+import android.database.SQLException;
 
 import androidx.core.util.Consumer;
 
@@ -513,7 +514,15 @@ public class Bucket<T extends Syncable> {
         } catch (GhostMissingException e) {
             throw(new BucketObjectMissingException(String.format("Bucket %s does not have object %s", getName(), key)));
         }
-        T object = mStorage.get(key);
+
+        // Check if there isn't an SQLException (e.g. SQLiteBlobTooBigException) to avoid propageting an unchecked
+        // exception.
+        T object;
+        try {
+            object = mStorage.get(key);
+        } catch (SQLException e) {
+            throw(new BucketObjectMissingException(String.format("Bucket %s does not have object %s", getName(), key), e));
+        }
         if (object == null) {
             throw(new BucketObjectMissingException(String.format("Storage provider for bucket:%s did not have object %s", getName(), key)));
         }


### PR DESCRIPTION
On Simplenote, we get crashes when a note is big and exceeds the SQLite row size (2 MB). We are going to catch `SQLException` and return a missing object for the cases in which we get an exception. 