### PR TITLE
Move requestWindowFeature before onCreate

### DIFF
--- a/Simperium/src/main/java/com/simperium/android/AuthenticationActivity.java
+++ b/Simperium/src/main/java/com/simperium/android/AuthenticationActivity.java
@@ -17,8 +17,8 @@ public class AuthenticationActivity extends AppCompatActivity implements LoginSh
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        super.onCreate(savedInstanceState);
         this.setTheme(R.style.Simperium);
         setContentView(R.layout.activity_authentication);
 


### PR DESCRIPTION
## What

When updating [kotlin on simple note](https://github.com/Automattic/simplenote-android/pull/1664), it crashed due to the  `requestWindowFeature` being called after `onCreate`. I don't fully understand the issue. But a quick google search pointed out that it should be called before `onCreate`.

## Test

You can load the PR linked to see how it works. Before the app loading crashed immediately. No immediate crash means it's fixed.