### PR TITLE
Update Background Color Resources

### DIFF
--- a/Simperium/src/main/res/layout-land/activity_authentication.xml
+++ b/Simperium/src/main/res/layout-land/activity_authentication.xml
@@ -3,7 +3,8 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="@android:color/white"
+    android:id="@+id/activity_authentication_root"
+    android:background="@color/background"
     android:clipChildren="false"
     android:clipToPadding="false"
     android:layout_gravity="center_horizontal"

--- a/Simperium/src/main/res/layout/activity_authentication.xml
+++ b/Simperium/src/main/res/layout/activity_authentication.xml
@@ -4,7 +4,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_authentication_root"
-    android:background="@color/background_primary"
+    android:background="@color/background"
     android:clipToPadding="false"
     android:layout_gravity="center_horizontal"
     android:layout_height="match_parent"

--- a/Simperium/src/main/res/layout/activity_credentials.xml
+++ b/Simperium/src/main/res/layout/activity_credentials.xml
@@ -10,7 +10,7 @@
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
-        android:background="@color/background_primary"
+        android:background="@color/background"
         android:elevation="0dp"
         android:layout_height="?attr/actionBarSize"
         android:layout_width="match_parent"
@@ -22,7 +22,7 @@
     </androidx.appcompat.widget.Toolbar>
 
     <RelativeLayout
-        android:background="@color/background_primary"
+        android:background="@color/background"
         android:clipToPadding="false"
         android:layout_centerHorizontal="true"
         android:layout_height="match_parent"

--- a/Simperium/src/main/res/layout/sheet_login.xml
+++ b/Simperium/src/main/res/layout/sheet_login.xml
@@ -3,7 +3,7 @@
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="@color/background_primary"
+    android:background="@color/background"
     android:clipToPadding="false"
     android:layout_height="wrap_content"
     android:layout_width="@dimen/width_layout"

--- a/Simperium/src/main/res/values-night-v27/styles.xml
+++ b/Simperium/src/main/res/values-night-v27/styles.xml
@@ -3,14 +3,14 @@
 <resources>
 
     <style name="BottomSheetDialogTheme" parent="BaseBottomSheetDialog">
-        <item name="android:navigationBarColor">@color/background_primary</item>
+        <item name="android:navigationBarColor">@color/background</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="Simperium" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="android:navigationBarColor">@color/background_primary</item>
-        <item name="android:statusBarColor">@color/background_primary</item>
+        <item name="android:navigationBarColor">@color/background</item>
+        <item name="android:statusBarColor">@color/background</item>
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="colorAccent">@color/background_button_primary</item>

--- a/Simperium/src/main/res/values-night/colors.xml
+++ b/Simperium/src/main/res/values-night/colors.xml
@@ -2,7 +2,8 @@
 
 <resources>
 
-    <!-- APPLICATION - Dark Mode Colors -->
+    <!-- APPLICATION -->
+    <color name="background">@color/gray_1</color>
     <color name="background_button_disabled">@color/gray_40</color>
     <color name="background_button_primary">@color/primary</color>
     <color name="background_button_secondary">@color/gray_40</color>
@@ -18,7 +19,6 @@
     <color name="text_title">@android:color/white</color>
 
     <!-- Background colors for dark mode -->
-    <color name="background_primary">@color/gray_1</color>
     <color name="background_secondary">@color/gray_3</color>
 
 </resources>

--- a/Simperium/src/main/res/values-night/colors.xml
+++ b/Simperium/src/main/res/values-night/colors.xml
@@ -18,7 +18,4 @@
     <color name="text_subtitle">@color/gray_b</color>
     <color name="text_title">@android:color/white</color>
 
-    <!-- Background colors for dark mode -->
-    <color name="background_secondary">@color/gray_3</color>
-
 </resources>

--- a/Simperium/src/main/res/values-night/styles.xml
+++ b/Simperium/src/main/res/values-night/styles.xml
@@ -3,7 +3,7 @@
 <resources>
 
     <style name="BaseBottomSheetDialog" parent="Theme.MaterialComponents.DayNight.BottomSheetDialog">
-        <item name="android:colorBackground">@color/background_primary</item>
+        <item name="android:colorBackground">@color/background</item>
         <item name="android:windowIsFloating">false</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
     </style>
@@ -13,7 +13,7 @@
     </style>
 
     <style name="Simperium" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="android:statusBarColor">@color/background_primary</item>
+        <item name="android:statusBarColor">@color/background</item>
         <item name="android:windowLightStatusBar">false</item>
         <item name="colorAccent">@color/background_button_primary</item>
         <item name="colorPrimary">@color/background_button_primary</item>

--- a/Simperium/src/main/res/values-v27/styles.xml
+++ b/Simperium/src/main/res/values-v27/styles.xml
@@ -3,14 +3,14 @@
 <resources>
 
     <style name="BottomSheetDialogTheme" parent="BaseBottomSheetDialog">
-        <item name="android:navigationBarColor">@color/background_primary</item>
+        <item name="android:navigationBarColor">@color/background</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowLightNavigationBar">true</item>
     </style>
 
     <style name="Simperium" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="android:navigationBarColor">@color/background_primary</item>
-        <item name="android:statusBarColor">@color/background_primary</item>
+        <item name="android:navigationBarColor">@color/background</item>
+        <item name="android:statusBarColor">@color/background</item>
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="colorAccent">@color/background_button_primary</item>

--- a/Simperium/src/main/res/values/colors.xml
+++ b/Simperium/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
 <resources>
 
     <!-- APPLICATION -->
+    <color name="background">@android:color/white</color>
     <color name="background_button_disabled">@color/gray_b</color>
     <color name="background_button_primary">@color/primary</color>
     <color name="background_button_secondary">@color/gray_3</color>
@@ -18,7 +19,6 @@
     <color name="text_title">@color/gray_1</color>
 
     <!-- Background colors for light mode -->
-    <color name="background_primary">@android:color/white</color>
     <color name="background_secondary">@color/gray_b</color>
 
     <!-- STANDARD -->

--- a/Simperium/src/main/res/values/colors.xml
+++ b/Simperium/src/main/res/values/colors.xml
@@ -18,9 +18,6 @@
     <color name="text_subtitle">@color/gray_1</color>
     <color name="text_title">@color/gray_1</color>
 
-    <!-- Background colors for light mode -->
-    <color name="background_secondary">@color/gray_b</color>
-
     <!-- STANDARD -->
     <color name="gray_1">#111111</color>
     <color name="gray_3">#333333</color>

--- a/Simperium/src/main/res/values/styles.xml
+++ b/Simperium/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
 <resources>
 
     <style name="BaseBottomSheetDialog" parent="Theme.MaterialComponents.DayNight.BottomSheetDialog">
-        <item name="android:colorBackground">@color/background_primary</item>
+        <item name="android:colorBackground">@color/background</item>
         <item name="android:windowIsFloating">false</item>
         <item name="bottomSheetStyle">@style/Widget.Design.BottomSheet.Modal</item>
     </style>
@@ -13,7 +13,7 @@
     </style>
 
     <style name="Simperium" parent="Theme.MaterialComponents.DayNight.NoActionBar">
-        <item name="android:statusBarColor">@color/background_primary</item>
+        <item name="android:statusBarColor">@color/background</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="colorAccent">@color/background_button_primary</item>
         <item name="colorPrimary">@color/background_button_primary</item>


### PR DESCRIPTION
### Fix
Update the background color resources created in https://github.com/Simperium/simperium-android/pull/251 by renaming from `background_primary` to `background` and removing `background_secondary`.

### Test
There are no visual changes with this update, but it be tested in https://github.com/Automattic/simplenote-android/pull/1743 using the dependency below.

```
implementation 'com.automattic:simperium:252-fef1ca06ec6fe8367d79931bd388244aee5beb18'
```

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.